### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/daily_data_fetch.yml
+++ b/.github/workflows/daily_data_fetch.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * *'  # Run daily at midnight UTC
   workflow_dispatch: #allow to run manually
 
+permissions:
+  contents: write
+
 jobs:
   fetch_and_update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/akzedevops/mmeqopendata/security/code-scanning/1](https://github.com/akzedevops/mmeqopendata/security/code-scanning/1)

Add an explicit `permissions` block to the workflow (or job).  
Best single fix without changing behavior: set workflow-level permissions to `contents: write`, since this workflow commits and pushes to the repository and also performs checkout. This keeps required functionality while constraining token scope to repository contents only.

**File to edit:** `.github/workflows/daily_data_fetch.yml`  
**Change location:** after the `on:` section (before `jobs:`).  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
