### PR TITLE
Next-phase plans (Draft specs): data-fetch upgrade, Go rewrite, project improvements

### DIFF
--- a/specs/001-data-fetch-upgrade.md
+++ b/specs/001-data-fetch-upgrade.md
@@ -1,0 +1,121 @@
+---
+spec: 001
+title: Upgrade the earthquake data-fetch/export system
+status: Draft            # Draft | Approved | In progress | Done
+author: Claude (research) + Aung Khant Zaw
+created: 2026-06-30
+---
+
+## Problem / motivation
+
+The fetch/export subsystem has correctness and completeness gaps that were uncovered
+by research (3-agent audit + live API probes). Two are **verified and serious**:
+
+1. **The API silently caps at 500 records per request, newest-first, with NO pagination.**
+   Probed live: `GET /api/myanmar-quakes?from=2025-03-01&to=2025-03-31` returns *exactly*
+   500 records, earliest `2025-03-29` — i.e. **the 2025-03-28 M7.7 mainshock and three
+   weeks of its aftershocks are unreachable in a single monthly window.** The response is a
+   bare `{"earthquakes": [...]}` — no `total`/`limit`/`offset`/cursor/`next`, no
+   ETag/If-Modified-Since. The current month-window strategy only produced a complete
+   catalog because it accreted over hundreds of daily runs while each day stayed < 500.
+   **A full rebuild from the API today would truncate every >500-event window** — the
+   project's headline event would be lost. Disaster recovery is effectively broken.
+
+2. **The combined JSON is desynced from the CSV: 421 records vs 9,390** (verified on disk).
+   `merge_combined_json` accumulates against the existing JSON using only *this run's*
+   fetched months, while the CSV accumulates correctly; the two drifted and nothing
+   reconciles. The public JSON artifact is missing ~95% of events.
+
+Additional issues (from code reading): no atomic writes (in-place writes can corrupt the
+canonical state store on a crash), the combined CSV *is* the implicit state store (no
+manifest/high-water-mark file), thin retry config (no 429 handling, no jitter, no rate
+limit across the 10 concurrent workers), no response-schema/contract validation, no
+"window returned exactly the cap → suspect truncation" detection, past-month revisions are
+never re-fetched, and `dataexport.py` (run by CI) is a drifting duplicate of
+`src/mmeq/export/*` (see [[003-project-improvements]]).
+
+## Goal
+
+A fetch/export system that (a) returns *complete* data for any window regardless of the
+500-cap, (b) keeps CSV and JSON in sync, (c) writes atomically and tracks state
+explicitly, and (d) fails loudly on truncation/contract violations instead of silently
+shipping incomplete data to the public dashboard.
+
+## Non-goals
+
+- The Go rewrite (that is [[002-go-export-rewrite]]; this spec is Python-side and must land
+  first so the Go port has a correct, tested reference).
+- Changing the analysis/figure pipeline.
+- Changing the upstream API (we don't control mmeq.akze.net).
+
+## Design
+
+Changes land in `src/mmeq/export/{fetcher,writer}.py`, `src/mmeq/config.py`,
+`src/mmeq/cli.py`, and the two workflows. `dataexport.py` is retired in favour of
+`mmeq export` (R2) so fixes actually reach production.
+
+- **R1 — Adaptive window bisection (the key fix).** In `fetcher.py`, when a window returns
+  `>= MMEQ_API_PAGE_CAP` (default 500) records, recursively split the date window
+  (month → days → hours) and union the de-duplicated results until every sub-window is
+  under the cap. New config `MMEQ_API_PAGE_CAP=500`. This is the only way to get complete
+  data for active sequences and to make full rebuild correct.
+- **R3 — Atomic writes + JSON reconcile.** All writers write `*.tmp` then `os.replace(...)`.
+  Add `mmeq export --rebuild` that regenerates the combined JSON (and re-sorts the combined
+  CSV by `time_utc`) from the full set of monthly files, fixing the 421-vs-9,390 drift.
+- **R4 — Explicit state manifest.** Write `quake_exports/_manifest.json`:
+  `{last_event_utc, last_run_utc, total_events, per_month_counts, cap_hit_windows[]}`.
+  `get_last_updated_date()` reads it (falling back to the CSV scan). Underpins R1 re-slicing
+  and the freshness badge.
+- **R5 — Harden HTTP.** Add `429` to `status_forcelist`, `respect_retry_after_header=True`,
+  separate connect/read retries, backoff jitter, and a small inter-request delay or lower
+  default `MAX_WORKERS` so concurrent workers don't trip rate limits.
+- **R6 — Contract + data-quality gate.** Validate required fields per record
+  (`id, time, latitude, longitude, depth, mag`); after a run, assert no month shrank
+  unexpectedly and log dedup/per-window counts; treat `len == cap` as "truncated → bisect"
+  (ties to R1) and a contract violation as a non-zero CI exit with a clear message.
+- **R2 — Unify CI on the package.** Point `daily_data_fetch.yml` at `mmeq export`; reduce
+  `dataexport.py` to a shim or delete it. (Shared with [[003-project-improvements]] #3.)
+- **R8 — CI push safety.** Add a `concurrency:` group to `daily_data_fetch.yml` and
+  `git pull --rebase origin master` before push in both workflows (two workflows push to
+  master today with no rebase → non-fast-forward risk).
+- **R10 — Weekly look-back.** Once a week, re-fetch the trailing ~90 days so revised
+  magnitudes/locations land via the existing `id`-keyed `keep="last"` dedup.
+
+Deferred / optional: **R7** (Parquet/DuckDB combined catalog as the analytical
+source-of-truth — a duckdb MCP already exists here) and **R9** (freshness badge + CI
+failure alerting). Capture as follow-ups, not blockers.
+
+## Data & outputs impact
+
+- Input: same API; new `quake_exports/_manifest.json`.
+- Artifacts: combined JSON repopulated to ~9,390 records; combined CSV sorted by time;
+  monthly/yearly unchanged in shape. Re-sorting the combined CSV is a one-time large diff.
+- Derived numbers: a corrected full rebuild may *add* previously-truncated events
+  (e.g. early-March-2025 aftershocks) → b-value, counts, and dam/PSHA numbers in README +
+  paper must be re-verified and regenerated together (CI already does figures/paper).
+
+## Acceptance criteria
+
+- [ ] New `tests/test_fetcher.py` case: a stubbed API returning 500 for a month and < 500
+      for sub-windows yields the *union* (bisection recovers all records).
+- [ ] `mmeq export --rebuild` produces a combined JSON whose record count equals the
+      combined CSV row count (currently 421 vs 9,390 → must match).
+- [ ] Atomic-write test: an interrupted write leaves the previous file intact (no partial).
+- [ ] A window returning exactly the cap is logged/flagged and bisected (assert in test).
+- [ ] `daily_data_fetch.yml` runs `mmeq export`; `dataexport.py` no longer the CI entry.
+- [ ] No regression: full `pytest tests/ -v` green.
+
+## Risks / rollback
+
+- R1 bisection could multiply API calls on dense windows — bound recursion depth and add
+  rate limiting (R5). Risk: low.
+- Re-sorting/rebuilding combined files is a big one-time diff and changes the public JSON;
+  do it in one reviewed commit. Rollback = revert the commit (history preserves old files).
+- Migrating CI off `dataexport.py` changes the production path — gate behind the new
+  pytest CI job ([[003-project-improvements]] #1) and a shadow run before cutover.
+
+## Notes
+
+API probes (2026-06-30): `2025-03-01..03-31` → 500 recs, earliest 2025-03-29;
+`2025-03-28..04-30` → 500 recs, 04-19..04-30 only; quiet windows return true counts.
+Only top-level key is `earthquakes`. Combined JSON on disk: 421; CSV: 9,390.

--- a/specs/002-go-export-rewrite.md
+++ b/specs/002-go-export-rewrite.md
@@ -1,0 +1,117 @@
+---
+spec: 002
+title: Rewrite the fetch/export CLI in Go (single static binary) on a separate branch
+status: Draft            # Draft | Approved | In progress | Done
+author: Claude (research) + Aung Khant Zaw
+created: 2026-06-30
+---
+
+## Problem / motivation
+
+The daily data-fetch CI installs the **entire scientific Python stack**
+(`pip install -e ".[dev]"` + plotly/fpdf2 → pandas, numpy, scipy, sklearn, geopandas,
+contextily, shapely, pyproj, matplotlib) just to run an HTTP-and-CSV job
+(`python dataexport.py`). That is slow, flaky, and heavy for what is fundamentally an
+I/O-bound fetch → validate → dedup → export task. A Go rewrite of *only that pipeline*
+yields a single static binary with fast cold start, trivial concurrency, and zero Python
+dependency for the daily cron — while the scientific analysis stays in Python where it
+belongs.
+
+This is a **separate-branch** effort (`feat/go-export-rewrite`) because it is large and
+must not destabilize the live pipeline; it lands only after a shadow-run proves byte-parity.
+
+## Goal
+
+A `mmeq-export` Go binary that reproduces the Python export output **byte-for-byte**
+(golden-file tested) and replaces `python dataexport.py` in `daily_data_fetch.yml`, with the
+scientific analysis + figures + dashboard + paper untouched (they keep reading the CSV/JSON
+the binary produces). The CSV/JSON artifact is the contract boundary: **Go produces it,
+Python consumes it.**
+
+## Non-goals
+
+- **Do NOT port any scientific code.** All of `analysis/` (ASK08 GMPE, PSHA, DBSCAN,
+  declustering, fragility, Coulomb, Monte-Carlo) and `visualization/` + `generate_figures.py`
+  stay in Python. No mature Go equivalent for numpy/scipy/sklearn/geopandas/rasterio/
+  matplotlib, and rewriting them risks silent numerical divergence in *published* claims —
+  exactly what CLAUDE.md forbids.
+- Not a rewrite of the CLI's `analyze/visualize/report` subcommands — only `export`.
+
+## Design
+
+Port classification (from the codebase map):
+
+| Component | Port to Go? | Why |
+|---|---|---|
+| `export/fetcher.py`, `export/writer.py`, `config.py`, `cli.py:cmd_export`, `dataexport.py` | **PORT** | I/O-bound, concurrency, simple transforms, single-binary value |
+| `analysis/geocoder.py` (point-in-polygon ADM1/2/3 + nearest OSM place + haversine; emits 6 published columns inside `validate_quake_data`) | **PORT (with care)** — or hybrid | Pure geometry, but fidelity-sensitive (see risks) |
+| everything else in `analysis/` and `visualization/` | **KEEP (Python)** | SciPy-stack bound, peer-review-grade |
+
+Recommended Go layout (separate module under `go/` or repo subdir):
+```
+cmd/mmeq-export/main.go         # cobra root + `export` subcommand
+internal/config/                # MMEQ_* env parsing (mirror config.py)
+internal/api/                   # retryablehttp client; fetch(from,to) -> []Quake
+internal/catalog/               # model, validate, dedup, daterange, writer
+internal/geocoder/              # admin polygons (orb) + nearest place (kd-tree) [optional]
+testdata/                       # golden CSV/JSON from current Python output
+```
+
+Libraries (verified current, mid-2026): stdlib `net/http` + `hashicorp/go-retryablehttp`
+(v0.7.8) for retries/backoff; stdlib `encoding/csv`,`encoding/json`; `spf13/cobra` for the
+CLI; `golang.org/x/sync/errgroup` with `SetLimit(workers)` to mirror `ThreadPoolExecutor`;
+`time.LoadLocation("Asia/Yangon")` + `time/tzdata` (embedded) for `time_mmt`; `paulmach/orb`
+(planar polygon-contains) + a kd-tree (`kyroy/kdtree` or gonum) for the geocoder.
+
+**Contract behaviors that must be reproduced exactly** (golden-file tested): validation
+bounds (lat/lon/depth/mag) + NaN-drop; `time_utc` UTC `%Y-%m-%d %H:%M:%S` and `time_mmt` in
+Asia/Yangon (UTC+06:30, via tzdb not a hardcoded offset); `id`-keyed dedup `keep="last"`;
+combined-JSON merge keyed on id else `(time_utc,lat,lon)` preserving first-seen order;
+monthly = overwrite, yearly/combined = merge+dedup; date-range generation from
+`last_event + 1 day`; the 33-column CSV header/order ending in the 6 geocoder columns +
+`shakemapURL/shakemapLastUpdated`; JSON `{"earthquakes":[...]}` indent=2, UTF-8 literal
+(non-ASCII Myanmar names). **The Go port must also implement [[001-data-fetch-upgrade]]'s
+500-cap bisection and contract gate** — so 001 should land first as the reference.
+
+## Data & outputs impact
+
+- No change to artifact *shapes* — the Go binary must emit identical CSV/JSON.
+- `daily_data_fetch.yml` loses the `pip install` step and calls the Go binary.
+
+## Acceptance criteria
+
+- [ ] `go test ./...` passes, including golden-file tests diffing Go output against
+      snapshots of the current Python `mmeq export` output for several date ranges.
+- [ ] Byte-identical combined/monthly/yearly CSV+JSON vs Python on the same input (modulo a
+      documented, golden-tested float-formatting rule).
+- [ ] Geocoder parity: the 6 columns match Python on a fixture set (distance_km within a
+      stated rounding tolerance), OR the hybrid Python post-step is wired and tested.
+- [ ] A **shadow CI job** runs the Go binary alongside Python for ≥3 daily cycles with clean
+      diffs before any cutover.
+- [ ] After cutover, `daily_data_fetch.yml` has no Python dependency and the daily commit is
+      unchanged in content.
+
+## Risks / rollback
+
+- **Timezone / time formatting** — parse as UTC, convert via embedded tzdb; verify the
+  +06:30 half-hour offset survives. High-fidelity risk.
+- **Float formatting** — pandas `to_csv` float repr vs Go `strconv.FormatFloat`; use
+  shortest round-trip (`'g',-1,64`) and golden-test; cosmetic drift creates noisy daily git
+  diffs and can break exact-match parsers.
+- **Geocoder fidelity** — scipy `cKDTree` uses 3D-unit-sphere Euclidean nearest then
+  haversine; shapely `STRtree.contains` boundary/multipolygon semantics must match orb.
+  Ties and boundary points are where Go can pick a different place. Mitigation: hybrid
+  fallback (Go writes pre-geocode CSV; a ~150-LOC Python step adds the 6 columns).
+- **Permissive schema** — pandas auto-absorbs new API keys (`shakemapURL` appeared later); a
+  fixed Go struct silently drops them. Use a struct + overflow `map[string]any`.
+- **Porting the wrong reference** — `dataexport.py` and `src/mmeq/export/*` have drifted;
+  port from the canonical package *after* [[003-project-improvements]] #3 unifies them.
+- Rollback at any phase: revert `daily_data_fetch.yml` to `python dataexport.py`; the branch
+  is isolated until cutover so the live pipeline is never at risk.
+
+## Notes
+
+Migration path: golden-snapshot Python output → build Go binary in parallel (not wired to
+CI) → geocoder decision (full Go vs hybrid) → shadow CI diff job → cutover → deprecate
+`dataexport.py`. The scientific pipeline never changes, insulating the public dashboard.
+Sources: go-retryablehttp, paulmach/orb, spf13/cobra, gonum/kyroy kd-tree (see research).

--- a/specs/003-project-improvements.md
+++ b/specs/003-project-improvements.md
@@ -1,0 +1,126 @@
+---
+spec: 003
+title: Project improvements — CI test gate, de-duplication, structure, readability
+status: Draft            # Draft | Approved | In progress | Done
+author: Claude (research) + Aung Khant Zaw
+created: 2026-06-30
+---
+
+## Problem / motivation
+
+A project-wide audit (research only) found maintainability/structure issues that are not
+correctness bugs but raise the risk of *future* silent breakage of the published dashboard
+and paper. The biggest: **no test gate before deploy**, **duplicated/drifting code paths**
+(`dataexport.py` vs `src/mmeq/export/*`; `report/` vs `docs/report/`), and analysis run
+**twice per CI build**. These compound the data-fetch and Go work, so fixing them first
+makes 001/002 cleaner.
+
+## Goal
+
+A repo where every push that ships to the public dashboard passes `pytest` first, the
+export/report/figure paths route through `mmeq` subcommands (no duplicated scripts, no
+double-computation), tunables live in `config.py`, and lint/format is enforced.
+
+## Non-goals
+
+- No scientific/numeric changes (those are correctness specs, already handled).
+- Not a full rewrite of `generate_figures.py` internals beyond modularization needed to
+  test/route it.
+
+## Design — ranked work items
+
+**P1 — Add a pytest CI gate (S, High).** New `test` job (`pip install -e ".[dev]" && pytest
+tests/ -v`); make `report_and_pages.yml` `build`/`deploy` `needs: test`. Today neither
+workflow runs tests, yet `report_and_pages` ships analysis straight to Pages on every
+master push — the silent-ship risk CLAUDE.md warns about.
+
+**P2 — Unify `report/` vs `docs/report/` and stop double-computing (M, High).** CI runs
+`tools/build_figure_data.py` (writes `report/dam_risk_scores.csv`) *and*
+`mmeq report --output docs/report` (recomputes the same). Read paths are inconsistent
+(`generate_figures.py`→`report/`, `shakemap_validation.py:15` hardcoded, `fragility.py:183`
+cwd-relative, `dam_risk.py` `_load_vs30` uses `MMEQ_REPORT_DIR`). Thread one `report_dir`
+everywhere and have `mmeq report` consume the already-built CSVs instead of recomputing.
+
+**P3 — Retire `dataexport.py` duplication (M, High).** It re-implements
+`validate_quake_data`/`_dedup_frame`/`save_to_csv`/`save_to_json`/`generate_date_ranges`/
+`fetch_quake_data` already in `src/mmeq/export/*`, and has already drifted (its
+`save_to_json` lacks `ensure_ascii=False`; bounds copy-pasted from `config.py`). Make
+`daily_data_fetch.yml` run `mmeq export`; reduce `dataexport.py` to a shim or delete.
+(Shared with [[001-data-fetch-upgrade]] R2 and a prerequisite for [[002-go-export-rewrite]].)
+
+**P4 — Test the published-number functions (M, High).** Zero tests for `coulomb`,
+`fragility`, `osm_exposure`, `population*`, `shakemap_validation`, `temporal`, `geocoder`,
+`finite_fault`, `gem_faults`, and within `dam_risk` the consequential
+`dam_risk_scores`/`monte_carlo_pga`/`sensitivity_analysis`/`compute_hazard_curve`. Add unit
+tests for grade thresholds, hazard return-period inversion, fragility lognormal CDF, plus an
+end-to-end `mmeq report --no-pdf --no-animated …` smoke test over a ~50-row fixture (would
+also catch the cluster-image bug below).
+
+**P5 — Hoist magic numbers into `config.py` + one scoring helper (S, Med).** Risk weights
+`0.35/0.30/0.20/0.15`, grade thresholds `7/5/3`, `seismic_score = pga/0.05*10`, exposure
+`h*0.3+c*0.02+s*0.005`, and `sigma_ln=0.65` are inlined in *both* `dam_risk_scores` and
+`sensitivity_analysis` — tune one, the two analyses silently diverge. Centralize and share a
+`_score_dam()` helper.
+
+**P6 — Delete dead legacy scripts (S, Med).** `advanalysis.py`, `adv2analysis.py`,
+`visualizer.py` are referenced only by CLAUDE.md's "do not edit" note (zero imports/workflow
+refs). Delete (git preserves history) or move to `archive/`, and drop the CLAUDE.md note.
+
+**P7 — Add ruff + pre-commit + lint CI step; trim redundant pip installs (S, Med).** No
+linter/formatter today. Add `ruff` (lint+format) to the `dev` extra and a CI lint step.
+Remove the dead `pip install plotly fpdf2` lines (already in `pyproject` deps) from both
+workflows.
+
+**P8 — Promote `tools/build_figure_data.py` to `mmeq build-figure-data` and modularize
+`generate_figures.py` (M, Med).** Remove the `sys.path.insert`/`from src.mmeq` hacks and the
+mixed `src.mmeq`/`mmeq` import roots; wrap each of the 14 figures in a function with a
+`--only N` flag so one figure can regenerate/test in isolation (today an exception in fig 7
+aborts 8–13; only fig14 is guarded).
+
+**P9 — Centralize data-file paths off `os.getcwd()` (M, Med).** `dam_risk.py:14,34`,
+`coulomb.py:298`, `map.py:18`, `clustering.py:200`, `population.py:18`, `gem_faults.py:5`
+locate files via `os.getcwd()` — breaks when `mmeq` runs from any other dir. Add a
+package-relative `DATA_DIR`/`PROJECT_ROOT` in `config.py`.
+
+**P10 — Vectorize `sensitivity_analysis` (M, Med).** It recomputes per-dam PGA/fault-distance
+inside its 100-sample Monte-Carlo loop (100 × 254 × N_segments) though only the weights
+change. Precompute per-dam terms once, vectorize the weight sampling.
+
+**Incidental bug to fix in P4/P8:** `cmd_report` (`cli.py:348`) passes a
+`earthquake_clusters.png` to the PDF that only `cmd_analyze` generates, so the report PDF's
+cluster image is silently missing in CI. Generate it in `cmd_report` or drop the arg.
+
+## Data & outputs impact
+
+- No artifact-shape changes intended. P2/P8 may change which dir figures read from; verify
+  figures + numbers regenerate identically (golden compare before/after).
+
+## Acceptance criteria
+
+- [ ] CI `test` job runs `pytest` and `report_and_pages` deploy `needs: test` (P1).
+- [ ] `dam_risk_scores` computed once per CI build (P2) — assert no duplicate compute in the
+      workflow logs / refactor removes the second call.
+- [ ] `daily_data_fetch.yml` runs `mmeq export`; `dataexport.py` retired (P3).
+- [ ] New tests for `dam_risk_scores`, `compute_hazard_curve`, `fragility`, + report smoke
+      test; coverage of analysis modules rises measurably (P4).
+- [ ] Risk weights/thresholds/`sigma_ln` sourced from `config.py`; both analyses use the
+      shared helper (P5).
+- [ ] `ruff check` clean in CI; dead scripts gone (P6/P7).
+- [ ] No regression: full `pytest tests/ -v` green; figures + paper regenerate identically.
+
+## Risks / rollback
+
+- P2/P3 touch the production CI path — land behind the P1 test gate and verify a full
+  `report_and_pages` dry run (workflow_dispatch on branch) regenerates identical figures
+  before merge.
+- P8 modularization could change figure rendering subtly — golden-compare PNG/PDF (with
+  `SOURCE_DATE_EPOCH` pinned) before/after.
+- Each item is independently revertable; sequence P1 → P6/P7 (quick wins) → P2/P3/P8
+  (structural) → P4/P5/P9/P10.
+
+## Notes
+
+Quick wins first (P1, P6, P7, P5). The structural items (P2, P3, P8) share one root cause —
+export/report/figure logic living *outside* the CLI — so routing everything through `mmeq`
+subcommands resolves duplication, reproducibility, and double-compute together, and is the
+foundation [[002-go-export-rewrite]] ports from.

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,5 +41,7 @@ new spec from `TEMPLATE.md`, then drive steps 2–5 until every acceptance crite
 
 | Spec | Title | Status |
 |------|-------|--------|
-| _none yet_ | | |
+| [001](001-data-fetch-upgrade.md) | Upgrade the earthquake data-fetch/export system | Draft |
+| [002](002-go-export-rewrite.md) | Rewrite the fetch/export CLI in Go (separate branch) | Draft |
+| [003](003-project-improvements.md) | Project improvements — CI test gate, de-duplication, structure | Draft |
 </content>


### PR DESCRIPTION
Research-backed **Draft specs** for the next phase (spec-first workflow — review/approve before implementation). Produced from a 3-agent research fan-out plus verified live API probes.

## Key verified findings
- **The API silently caps at 500 records/request, no pagination.** A full-month `2025-03` query returns only 03-29→03-31 — **the M7.7 mainshock and 3 weeks of aftershocks are unreachable in one call**. The catalog is complete today only by daily accretion; a full rebuild would truncate history. (spec 001)
- **Combined JSON is desynced: 421 records vs the CSV's 9,390** (~95% missing). (spec 001)

## Specs
- **[001 data-fetch upgrade](specs/001-data-fetch-upgrade.md)** — adaptive window bisection (defeat the 500-cap), atomic writes + JSON reconcile/rebuild, state manifest, contract/cap-hit gate, hardened retries (429/jitter), unify CI on the package.
- **[002 Go rewrite](specs/002-go-export-rewrite.md)** — port **only** the fetch/validate/dedup/export CLI (+ geocoder) to a single static Go binary; keep all SciPy analysis + figures in Python; golden-file migration with a shadow run before cutover. Branch `feat/go-export-rewrite` is scaffolded (compiles, no port yet).
- **[003 project improvements](specs/003-project-improvements.md)** — add a **pytest CI gate before deploy**, unify `report/` vs `docs/report/` + stop double-computing, retire the `dataexport.py` duplicate, test the published-number functions, hoist magic numbers to config, ruff/pre-commit, delete dead legacy scripts.

## Suggested sequence
003 (quick wins + unify CLI) → 001 (correct Python reference) → 002 (Go port from the unified, tested reference).

No code/behavior changed in this PR — specs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)