### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/akzedevops/mmeqopendata/security/code-scanning/2](https://github.com/akzedevops/mmeqopendata/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/tests.yml` at the workflow root so it applies to all jobs (including `test`). The minimal required permission for this workflow is:

- `contents: read`

This preserves existing functionality (checkout, cache, setup-python, pip install, lint, tests) while enforcing least privilege for `GITHUB_TOKEN`. No imports, methods, or dependency changes are needed—only YAML configuration near the top of the file, between `on:` and `jobs:` (or directly after `name:`/`on:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
