### PR TITLE
ci: nightly fetch via mmeq API v2

### DIFF
--- a/.github/workflows/daily_data_fetch.yml
+++ b/.github/workflows/daily_data_fetch.yml
@@ -38,6 +38,10 @@ jobs:
 
       - name: Run data export
         run: mmeq export
+        env:
+          # Fetch from the mmeq API v2 (typed JSON, SQLite-backed — no live
+          # third-party proxying). Unset/empty falls back to the v1 endpoint.
+          MMEQ_API_V2_URL: https://mmeq.akze.net/api/v2
 
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
One-line cutover: sets `MMEQ_API_V2_URL` on the nightly export step.

**Merge order:** after PR #14 (fetcher v2 support) is merged AND the v2 nginx route is live on the server. Roll back by removing the env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)