### PR TITLE
ci: fix Pages artifact-push race (rebase + retry)

### DIFF
--- a/.github/workflows/report_and_pages.yml
+++ b/.github/workflows/report_and_pages.yml
@@ -102,7 +102,13 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/ paper/figures/ paper/main.pdf
           git diff --cached --quiet || git commit -m "docs: update report, figures & paper [skip ci]"
-          git push origin master
+          # master may have moved during the ~8 min build (e.g. a PR merge or the
+          # daily data commit) — rebase the artifact commit onto the new tip and
+          # retry so a non-fast-forward doesn't fail the whole deploy.
+          for i in 1 2 3; do
+            git push origin master && break
+            git pull --rebase origin master || exit 1
+          done
 
       - name: Setup Pages
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
The Pages build failed on the PR #14 merge because master moved (PR #15) during its ~8-min build → non-fast-forward push rejection. This rebases the artifact commit onto the moved tip and retries (3x). Manual re-run of the workflow already dispatched to refresh the dashboard meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)