### PR TITLE
spec 003: single risk compute per CI build, config-sourced weights/σ, +13 tests

### DIFF
--- a/.github/workflows/report_and_pages.yml
+++ b/.github/workflows/report_and_pages.yml
@@ -74,9 +74,12 @@ jobs:
         run: python tools/build_figure_data.py
 
       - name: Generate full report
+        # --reuse-risk: build_figure_data.py already computed report/dam_risk_scores.csv
+        # in the previous step, so the report consumes it instead of recomputing
+        # (spec 003 P2 — dam risk is computed once per CI build).
         run: |
           mkdir -p docs/report
-          mmeq report --output docs/report
+          mmeq report --output docs/report --reuse-risk
 
       - name: Copy static map
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased
+
+Spec 003 follow-up (P2/P4/P5). Pure refactor + tests + CI plumbing — all
+scientific outputs verified byte-identical (`dam_risk_scores.csv`,
+`sensitivity_analysis.csv`; grades still Critical 25 / High 148 / Moderate 67 /
+Low 14).
+
+### Added
+- `mmeq report --reuse-risk` (env: `MMEQ_REUSE_RISK=1`) — reuse a fresh
+  `dam_risk_scores.csv` from `MMEQ_REPORT_DIR` (default `report/`) instead of
+  recomputing it. `report_and_pages.yml` now passes the flag so dam risk is
+  computed once per CI build (`tools/build_figure_data.py` remains the single
+  producer). A CSV older than the catalog, missing, or invalid falls back to
+  recomputing, so standalone `mmeq report` behavior is unchanged.
+- Config tunables `RISK_WEIGHTS`, `RISK_GRADE_THRESHOLDS`, `GMPE_SIGMA_LN`
+  (overridable via `MMEQ_RISK_W_*`, `MMEQ_RISK_GRADE_*`, `MMEQ_GMPE_SIGMA_LN`).
+- Tests (64 → 77): hazard-curve monotonicity vs PGA level + exact
+  `catalog_years` rate scaling; fragility lognormal median crossing = 0.5,
+  monotonic damage-state exceedance, discrete-state normalization; grade
+  threshold boundaries from config; a `cmd_report` dam-risk smoke test on a
+  synthetic catalog (skips if `myanmar_dams.geojson` is absent); reuse +
+  staleness tests for `--reuse-risk`.
+
+### Changed
+- `dam_risk.py`: composite weights (0.35/0.30/0.20/0.15), grade thresholds
+  (7/5/3) and GMPE `sigma_ln` (0.65) are no longer inlined in
+  `dam_risk_scores`, `sensitivity_analysis`, `compute_hazard_curve` and
+  `monte_carlo_pga`; they come from `config.py`, and both scoring analyses now
+  share `_component_scores()`/`_grade()` helpers so they cannot silently
+  diverge (spec 003 P5).
+
 ## v2.0.2 — 2026-07-02
 
 Scientific-audit follow-up (verified against Gardner & Knopoff 1974, OpenQuake,

--- a/specs/003-project-improvements.md
+++ b/specs/003-project-improvements.md
@@ -10,6 +10,12 @@ created: 2026-06-30
 > `needs: test`), P3 (CI runs `mmeq export`; `dataexport.py` → shim), P6 (dead
 > legacy scripts deleted), P7 (ruff adopted, redundant pip installs trimmed)
 > shipped. Still open: P2, P4, P5, P8, P9, P10 + the incidental cluster-image bug.
+>
+> **Progress (2026-07-02):** P2 (dam risk computed once per CI build via
+> `mmeq report --reuse-risk` / `MMEQ_REUSE_RISK`), P4 (hazard-curve, fragility,
+> grade-threshold + report smoke tests; suite 64 → 77), P5 (weights/thresholds/
+> `sigma_ln` in `config.py`; shared `_component_scores`/`_grade` helpers) shipped;
+> outputs verified byte-identical. Still open: P8, P9, P10 + the cluster-image bug.
 
 ## Problem / motivation
 
@@ -103,13 +109,22 @@ cluster image is silently missing in CI. Generate it in `cmd_report` or drop the
 ## Acceptance criteria
 
 - [x] CI `test` job runs `pytest` + `ruff` and `report_and_pages` deploy `needs: test` (P1). *(PR #8)*
-- [ ] `dam_risk_scores` computed once per CI build (P2) — assert no duplicate compute in the
-      workflow logs / refactor removes the second call.
+- [x] `dam_risk_scores` computed once per CI build (P2) — `mmeq report --reuse-risk`
+      (env: `MMEQ_REUSE_RISK`) consumes the fresh `report/dam_risk_scores.csv` that
+      `tools/build_figure_data.py` already produced; `report_and_pages.yml` passes the
+      flag. Stale/missing CSVs fall back to recomputing, so standalone behavior is
+      unchanged.
 - [x] `daily_data_fetch.yml` runs `mmeq export`; `dataexport.py` reduced to a shim (P3). *(PR #8)*
-- [ ] New tests for `dam_risk_scores`, `compute_hazard_curve`, `fragility`, + report smoke
-      test; coverage of analysis modules rises measurably (P4).
-- [ ] Risk weights/thresholds/`sigma_ln` sourced from `config.py`; both analyses use the
-      shared helper (P5).
+- [x] New tests for `dam_risk_scores`, `compute_hazard_curve`, `fragility`, + report smoke
+      test; coverage of analysis modules rises measurably (P4). *(tests/test_dam_risk.py:
+      hazard-curve monotonicity + catalog-years scaling, fragility lognormal
+      median/monotonicity, config-sourced grade boundaries, `cmd_report` smoke test on a
+      synthetic catalog, and reuse/staleness tests — 6 → 19 tests, suite 64 → 77.)*
+- [x] Risk weights/thresholds/`sigma_ln` sourced from `config.py`
+      (`RISK_WEIGHTS`/`RISK_GRADE_THRESHOLDS`/`GMPE_SIGMA_LN`, all `MMEQ_*`-overridable);
+      both analyses use the shared `_component_scores()`/`_grade()` helpers (P5).
+      Verified byte-identical `dam_risk_scores.csv`/`sensitivity_analysis.csv` and
+      unchanged grades (Critical 25 / High 148 / Moderate 67 / Low 14).
 - [x] `ruff check` clean in CI; dead scripts gone (P6/P7). *(PR #8)*
 - [x] No regression: full `pytest tests/ -v` green (56 tests). *(PR #8)*
 

--- a/src/mmeq/analysis/dam_risk.py
+++ b/src/mmeq/analysis/dam_risk.py
@@ -7,7 +7,45 @@ import numpy as np
 import pandas as pd
 import json
 
+from mmeq.config import GMPE_SIGMA_LN, RISK_GRADE_THRESHOLDS, RISK_WEIGHTS
+
 logger = logging.getLogger(__name__)
+
+
+def _grade(composite: float) -> str:
+    """Map a composite risk score to its published grade (thresholds in config)."""
+    if composite >= RISK_GRADE_THRESHOLDS["critical"]:
+        return "Critical"
+    if composite >= RISK_GRADE_THRESHOLDS["high"]:
+        return "High"
+    if composite >= RISK_GRADE_THRESHOLDS["moderate"]:
+        return "Moderate"
+    return "Low"
+
+
+def _dam_size(dam) -> tuple:
+    """Parse (height_m, capacity_mw, total_storage_mcm) from a dam row, 0 if missing."""
+    vals = []
+    for key in ("height_m", "capacity_mw", "total_storage_mcm"):
+        try:
+            vals.append(float(dam.get(key) or 0))
+        except (ValueError, TypeError):
+            vals.append(0)
+    return tuple(vals)
+
+
+def _component_scores(pga: float, dist_fault: float, dist_to_major: float, dam) -> tuple:
+    """Shared 0-10 component scores used by dam_risk_scores AND sensitivity_analysis.
+
+    Returns (seismic, fault, proximity, exposure) scores. Keeping this in one
+    place guarantees the two analyses cannot silently diverge (spec 003 P5).
+    """
+    seismic_score = min(10, pga / 0.05 * 10)
+    fault_score = min(10, 10 / max(1, dist_fault / 10)) if not math.isnan(dist_fault) else 5
+    prox_score = min(10, 10 / max(1, dist_to_major / 50))
+    h, c, s = _dam_size(dam)
+    exposure_score = min(10, (h * 0.3 + c * 0.02 + s * 0.005) / 5)
+    return seismic_score, fault_score, prox_score, exposure_score
 
 
 def _load_fault_segments() -> list:
@@ -294,13 +332,17 @@ def compute_hazard_curve(
     min_mag: float = 5.0,
     max_mag: float = 8.0,
     delta_m: float = 0.1,
+    sigma_ln: float = GMPE_SIGMA_LN,
 ) -> pd.DataFrame:
     """
     Compute a seismic hazard curve (PGA vs annual exceedance probability)
     at a given site using the Cornell-McGuire PSHA approach.
 
     a_val is the catalog-level a-value; it is converted to annual rate internally.
+    sigma_ln defaults to the ASK08 aleatory std-dev from config (GMPE_SIGMA_LN).
     """
+    from scipy.stats import norm
+
     if pga_levels is None:
         pga_levels = np.logspace(-3, 0, 50)
 
@@ -315,11 +357,9 @@ def compute_hazard_curve(
 
         pga_median = estimate_pga_ask08(mag=m, rrup_km=rjb_km, vs30=vs30)
 
-        sigma_ln = 0.65
         for i, pga_target in enumerate(pga_levels):
             if pga_median > 0:
                 epsilon = (math.log(pga_target) - math.log(pga_median)) / sigma_ln
-                from scipy.stats import norm
                 p_exceed = 1.0 - norm.cdf(epsilon)
                 rates[i] += n_per_year * p_exceed
 
@@ -385,7 +425,7 @@ def sensitivity_analysis(
         w = rng.dirichlet([1, 1, 1, 1])
         w_seismic, w_fault, w_prox, w_exp = w
 
-        critical = high = moderate = low = 0
+        counts = {"Critical": 0, "High": 0, "Moderate": 0, "Low": 0}
         for __, dam in dams_df.iterrows():
             dlat = dam["latitude"] - major_lat
             dlon = (dam["longitude"] - major_lon) * math.cos(math.radians(major_lat))
@@ -394,44 +434,22 @@ def sensitivity_analysis(
             rjb_km = dist_fault if (not math.isnan(dist_fault) and dist_fault > 0) else dist_to_major
             pga = estimate_pga(major_mag, major_depth, rjb_km)
 
-            seismic_score = min(10, pga / 0.05 * 10)
-            fault_score = min(10, 10 / max(1, dist_fault / 10)) if not math.isnan(dist_fault) else 5
-            prox_score = min(10, 10 / max(1, dist_to_major / 50))
-
-            try:
-                h = float(dam.get("height_m") or 0)
-            except (ValueError, TypeError):
-                h = 0
-            try:
-                c = float(dam.get("capacity_mw") or 0)
-            except (ValueError, TypeError):
-                c = 0
-            try:
-                s = float(dam.get("total_storage_mcm") or 0)
-            except (ValueError, TypeError):
-                s = 0
-            exposure_score = min(10, (h * 0.3 + c * 0.02 + s * 0.005) / 5)
+            seismic_score, fault_score, prox_score, exposure_score = _component_scores(
+                pga, dist_fault, dist_to_major, dam
+            )
 
             composite = seismic_score * w_seismic + fault_score * w_fault + prox_score * w_prox + exposure_score * w_exp
-
-            if composite >= 7:
-                critical += 1
-            elif composite >= 5:
-                high += 1
-            elif composite >= 3:
-                moderate += 1
-            else:
-                low += 1
+            counts[_grade(composite)] += 1
 
         results.append({
             "w_seismic": round(w_seismic, 3),
             "w_fault": round(w_fault, 3),
             "w_proximity": round(w_prox, 3),
             "w_exposure": round(w_exp, 3),
-            "critical": critical,
-            "high": high,
-            "moderate": moderate,
-            "low": low,
+            "critical": counts["Critical"],
+            "high": counts["High"],
+            "moderate": counts["Moderate"],
+            "low": counts["Low"],
         })
 
     return pd.DataFrame(results)
@@ -480,26 +498,17 @@ def dam_risk_scores(
         if len(nearby) == 0:
             nearby = eq_df
 
-        seismic_score = min(10, pga / 0.05 * 10)
-        fault_score = min(10, 10 / max(1, dist_fault / 10)) if not math.isnan(dist_fault) else 5
-        prox_score = min(10, 10 / max(1, dist_to_major / 50))
+        seismic_score, fault_score, prox_score, exposure_score = _component_scores(
+            pga, dist_fault, dist_to_major, dam
+        )
+        h, c, s = _dam_size(dam)
 
-        try:
-            h = float(dam.get("height_m") or 0)
-        except (ValueError, TypeError):
-            h = 0
-        try:
-            c = float(dam.get("capacity_mw") or 0)
-        except (ValueError, TypeError):
-            c = 0
-        try:
-            s = float(dam.get("total_storage_mcm") or 0)
-        except (ValueError, TypeError):
-            s = 0
-
-        exposure_score = min(10, (h * 0.3 + c * 0.02 + s * 0.005) / 5)
-
-        composite = seismic_score * 0.35 + fault_score * 0.30 + prox_score * 0.20 + exposure_score * 0.15
+        composite = (
+            seismic_score * RISK_WEIGHTS["seismic"]
+            + fault_score * RISK_WEIGHTS["fault"]
+            + prox_score * RISK_WEIGHTS["proximity"]
+            + exposure_score * RISK_WEIGHTS["exposure"]
+        )
 
         return_period_m6 = compute_return_period(6.0, b_val, a_val, catalog_years)
 
@@ -523,12 +532,7 @@ def dam_risk_scores(
             "proximity_score": round(prox_score, 1),
             "exposure_score": round(exposure_score, 1),
             "composite_risk": round(composite, 1),
-            "risk_grade": (
-                "Critical" if composite >= 7
-                else "High" if composite >= 5
-                else "Moderate" if composite >= 3
-                else "Low"
-            ),
+            "risk_grade": _grade(composite),
             "return_period_m6_yrs": round(return_period_m6, 1),
         })
 
@@ -540,7 +544,7 @@ def dam_risk_scores(
 def monte_carlo_pga(
     eq_df: pd.DataFrame,
     n_iterations: int = 1000,
-    sigma_ln: float = 0.65,
+    sigma_ln: float = GMPE_SIGMA_LN,
 ) -> pd.DataFrame:
     """
     Monte Carlo simulation of PGA uncertainty at all dam locations.

--- a/src/mmeq/cli.py
+++ b/src/mmeq/cli.py
@@ -230,6 +230,35 @@ def _build_interactive_map(df, output_dir, min_mag=0.0):
     return path
 
 
+def _load_precomputed_risk(catalog_path: str):
+    """Load a fresh, previously computed dam_risk_scores.csv, or return None.
+
+    Used by ``mmeq report --reuse-risk`` (env: MMEQ_REUSE_RISK) so CI does not
+    recompute risk scores that tools/build_figure_data.py already produced in
+    MMEQ_REPORT_DIR (default: report/) earlier in the same build (spec 003 P2).
+    The file is considered stale — and is recomputed — if it is older than the
+    catalog CSV it would be derived from.
+    """
+    report_dir = os.environ.get("MMEQ_REPORT_DIR", "report")
+    path = os.path.join(report_dir, "dam_risk_scores.csv")
+    if not os.path.exists(path):
+        logging.info(f"--reuse-risk: {path} not found; computing dam risk scores")
+        return None
+    if (
+        catalog_path
+        and os.path.exists(catalog_path)
+        and os.path.getmtime(path) < os.path.getmtime(catalog_path)
+    ):
+        logging.info(f"--reuse-risk: {path} is older than the catalog; recomputing")
+        return None
+    risk_df = pd.read_csv(path)
+    if risk_df.empty or "risk_grade" not in risk_df.columns:
+        logging.warning(f"--reuse-risk: {path} is empty/invalid; recomputing")
+        return None
+    logging.info(f"Reusing precomputed dam risk scores from {path} ({len(risk_df)} dams)")
+    return risk_df
+
+
 def cmd_report(args) -> None:
     from mmeq.analysis.dam_risk import dam_risk_scores
     from mmeq.analysis.aftershock import modified_omori_forecast
@@ -257,8 +286,14 @@ def cmd_report(args) -> None:
 
     risk_df = None
     if not args.no_dams:
-        logging.info("Computing dam risk scores...")
-        risk_df = dam_risk_scores(df, b, a, mc)
+        if getattr(args, "reuse_risk", False):
+            catalog_path = args.data or os.path.join(
+                EXPORT_DIR, "csv/combined/earthquakes_combined.csv"
+            )
+            risk_df = _load_precomputed_risk(catalog_path)
+        if risk_df is None:
+            logging.info("Computing dam risk scores...")
+            risk_df = dam_risk_scores(df, b, a, mc)
         if not risk_df.empty:
             risk_csv = os.path.join(args.output, "dam_risk_scores.csv")
             risk_df.to_csv(risk_csv, index=False)
@@ -454,6 +489,13 @@ def main() -> None:
     p_report.add_argument("--min-mag", type=float, default=0.0, help="Minimum magnitude filter")
     p_report.add_argument("--mc", type=float, default=None, help="Override magnitude of completeness")
     p_report.add_argument("--no-dams", action="store_true", help="Skip dam risk analysis")
+    p_report.add_argument(
+        "--reuse-risk",
+        action="store_true",
+        default=os.environ.get("MMEQ_REUSE_RISK", "").lower() in ("1", "true", "yes"),
+        help="Reuse a fresh dam_risk_scores.csv from MMEQ_REPORT_DIR (default: report/) "
+             "instead of recomputing it (env: MMEQ_REUSE_RISK=1)",
+    )
     p_report.add_argument("--no-forecast", action="store_true", help="Skip aftershock forecast")
     p_report.add_argument("--no-dashboard", action="store_true", help="Skip Plotly dashboard")
     p_report.add_argument("--no-3d", action="store_true", help="Skip 3D cross-section")

--- a/src/mmeq/config.py
+++ b/src/mmeq/config.py
@@ -51,6 +51,27 @@ MAG_COLORS = {
     "high": "red",
 }
 
+# --- Dam-risk scoring (spec 003 / P5) ---------------------------------------
+# Composite risk weights: seismic (scenario PGA), fault (distance to nearest
+# fault), proximity (distance to the major event), exposure (dam size). They
+# should sum to 1.0; used by analysis.dam_risk.dam_risk_scores.
+RISK_WEIGHTS = {
+    "seismic": float(os.environ.get("MMEQ_RISK_W_SEISMIC", "0.35")),
+    "fault": float(os.environ.get("MMEQ_RISK_W_FAULT", "0.30")),
+    "proximity": float(os.environ.get("MMEQ_RISK_W_PROXIMITY", "0.20")),
+    "exposure": float(os.environ.get("MMEQ_RISK_W_EXPOSURE", "0.15")),
+}
+# Composite-score cutoffs for the published risk grades:
+# >= critical -> Critical, >= high -> High, >= moderate -> Moderate, else Low.
+RISK_GRADE_THRESHOLDS = {
+    "critical": float(os.environ.get("MMEQ_RISK_GRADE_CRITICAL", "7")),
+    "high": float(os.environ.get("MMEQ_RISK_GRADE_HIGH", "5")),
+    "moderate": float(os.environ.get("MMEQ_RISK_GRADE_MODERATE", "3")),
+}
+# Total aleatory standard deviation of ln(PGA) for the ASK08 GMPE, used by both
+# the Cornell-McGuire PSHA integration and the Monte Carlo PGA simulation.
+GMPE_SIGMA_LN = float(os.environ.get("MMEQ_GMPE_SIGMA_LN", "0.65"))
+
 FAULT_LINES_PATH = os.environ.get("MMEQ_FAULT_LINES", "fault_lines.json")
 COMBINED_CSV = os.path.join(EXPORT_DIR, "csv/combined/earthquakes_combined.csv")
 COMBINED_JSON = os.path.join(EXPORT_DIR, "json/combined/earthquakes_combined.json")

--- a/tests/test_dam_risk.py
+++ b/tests/test_dam_risk.py
@@ -2,14 +2,26 @@
 
 These guard the v2 fixes for the broken large-distance coefficient (a18) and the
 un-annualized return period, both of which passed the original test suite because
-nothing exercised far-field PGA or the rate conversion.
+nothing exercised far-field PGA or the rate conversion. Spec 003 P4/P5 added
+hazard-curve, fragility, config-sourced scoring, and report smoke tests.
 """
+import argparse
 import math
+from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 
-from mmeq.analysis.dam_risk import estimate_pga_ask08, compute_return_period
+from mmeq.analysis.dam_risk import (
+    _grade,
+    compute_hazard_curve,
+    compute_return_period,
+    estimate_pga_ask08,
+)
+from mmeq.config import RISK_GRADE_THRESHOLDS, RISK_WEIGHTS
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestGmpeFarField:
@@ -55,3 +67,210 @@ class TestReturnPeriod:
 
     def test_zero_catalog_years_is_safe(self):
         assert compute_return_period(6.0, 1.0, 5.0, catalog_years=0) == math.inf
+
+
+class TestHazardCurve:
+    def test_exceedance_rate_monotonic_decreasing_in_pga(self):
+        hc = compute_hazard_curve(rjb_km=20.0, vs30=760.0, b_val=1.0, a_val=6.0, mc=4.0)
+        rates = hc["annual_rate"].to_numpy()
+        assert rates[0] > 0
+        # Exceedance rate must never increase with the PGA level.
+        assert (np.diff(rates) <= 1e-15).all()
+        # And it must actually decay over the full range.
+        assert rates[-1] < rates[0]
+
+    def test_catalog_years_scaling(self):
+        # a_val is a catalog-level intercept; annualizing divides by catalog
+        # years, so doubling the catalog length must halve every rate exactly.
+        hc1 = compute_hazard_curve(20.0, 760.0, 1.0, 6.0, 4.0, catalog_years=28.0)
+        hc2 = compute_hazard_curve(20.0, 760.0, 1.0, 6.0, 4.0, catalog_years=56.0)
+        np.testing.assert_allclose(
+            hc2["annual_rate"], hc1["annual_rate"] / 2.0, rtol=1e-9
+        )
+
+    def test_return_period_is_inverse_of_rate(self):
+        hc = compute_hazard_curve(20.0, 760.0, 1.0, 6.0, 4.0)
+        pos = hc[hc["annual_rate"] > 0]
+        np.testing.assert_allclose(
+            pos["return_period_yr"], 1.0 / pos["annual_rate"], rtol=1e-12
+        )
+
+
+class TestFragility:
+    def test_exceedance_decreasing_in_damage_state(self):
+        from mmeq.analysis.fragility import FRAGILITY_PARAMS, fragility_probability
+
+        for dam_type in FRAGILITY_PARAMS:
+            for pga in [0.05, 0.2, 0.5, 1.0, 1.5]:
+                p = fragility_probability(pga, dam_type)
+                assert p["DS1"] >= p["DS2"] >= p["DS3"] >= p["DS4"], (
+                    f"P(DS>=i) must be non-increasing in i ({dam_type}, {pga}g)"
+                )
+
+    def test_lognormal_median_crossing_is_half(self):
+        # At PGA equal to the fragility median, P(DS>=i) = Phi(0) = 0.5.
+        from mmeq.analysis.fragility import FRAGILITY_PARAMS, fragility_probability
+
+        for dam_type, params in FRAGILITY_PARAMS.items():
+            for ds, pr in params.items():
+                probs = fragility_probability(pr["median"], dam_type)
+                assert probs[ds] == pytest.approx(0.5, abs=1e-12)
+
+    def test_discrete_damage_states_sum_to_one(self):
+        from mmeq.analysis.fragility import damage_state_probabilities
+
+        for pga in [0.01, 0.2, 0.6, 1.5]:
+            p = damage_state_probabilities(pga, "earthfill")
+            assert sum(p.values()) == pytest.approx(1.0, abs=1e-9)
+
+    def test_zero_pga_no_damage(self):
+        from mmeq.analysis.fragility import fragility_probability
+
+        assert fragility_probability(0.0) == {
+            "DS1": 0.0, "DS2": 0.0, "DS3": 0.0, "DS4": 0.0
+        }
+
+
+class TestConfigSourcedScoring:
+    """Spec 003 P5: weights/thresholds come from config, not inline literals."""
+
+    def test_weights_sum_to_one(self):
+        assert sum(RISK_WEIGHTS.values()) == pytest.approx(1.0)
+
+    def test_published_defaults_unchanged(self):
+        assert RISK_WEIGHTS == {
+            "seismic": 0.35, "fault": 0.30, "proximity": 0.20, "exposure": 0.15
+        }
+        assert RISK_GRADE_THRESHOLDS == {"critical": 7.0, "high": 5.0, "moderate": 3.0}
+
+    def test_grade_boundaries(self):
+        assert _grade(RISK_GRADE_THRESHOLDS["critical"]) == "Critical"
+        assert _grade(RISK_GRADE_THRESHOLDS["critical"] - 0.01) == "High"
+        assert _grade(RISK_GRADE_THRESHOLDS["high"]) == "High"
+        assert _grade(RISK_GRADE_THRESHOLDS["high"] - 0.01) == "Moderate"
+        assert _grade(RISK_GRADE_THRESHOLDS["moderate"]) == "Moderate"
+        assert _grade(RISK_GRADE_THRESHOLDS["moderate"] - 0.01) == "Low"
+
+
+def _synthetic_catalog(n: int = 60) -> pd.DataFrame:
+    """Tiny plausible Myanmar catalog with one dominant M7.7 event."""
+    rng = np.random.RandomState(0)
+    df = pd.DataFrame({
+        "time_utc": pd.date_range("2015-01-01", periods=n, freq="30D"),
+        "mag": np.round(np.clip(3.0 + rng.exponential(0.8, n), 3.0, 7.0), 1),
+        "depth": np.round(rng.uniform(5.0, 40.0, n), 1),
+        "latitude": np.round(rng.uniform(16.0, 26.0, n), 3),
+        "longitude": np.round(rng.uniform(92.0, 100.0, n), 3),
+        "location": "Synthetic, Myanmar",
+    })
+    # Dominant scenario event (drives dam_risk_scores' major_eq selection).
+    df.loc[0, ["mag", "depth", "latitude", "longitude"]] = [7.7, 10.0, 22.0, 96.0]
+    return df
+
+
+def _report_args(catalog: Path, output: Path, **overrides) -> argparse.Namespace:
+    """cmd_report args with every stage disabled except dam risk."""
+    ns = argparse.Namespace(
+        data=str(catalog),
+        output=str(output),
+        min_mag=0.0,
+        mc=None,
+        reuse_risk=False,
+        no_dams=False,
+        no_forecast=True,
+        no_dashboard=True,
+        no_3d=True,
+        no_animated=True,
+        no_population=True,
+        no_buildings=True,
+        no_pdf=True,
+        no_clusters=True,
+        no_coulomb=True,
+        no_fragility=True,
+        no_montecarlo=True,
+    )
+    for k, v in overrides.items():
+        setattr(ns, k, v)
+    return ns
+
+
+class TestReportSmoke:
+    @pytest.mark.skipif(
+        not (REPO_ROOT / "myanmar_dams.geojson").exists(),
+        reason="myanmar_dams.geojson not available",
+    )
+    def test_report_dam_risk_only(self, tmp_path, monkeypatch):
+        from mmeq.cli import cmd_report
+
+        # Dam/fault inputs are resolved from the CWD.
+        monkeypatch.chdir(REPO_ROOT)
+        # Do not pick up a stale report/dam_vs30.csv from a dev checkout.
+        monkeypatch.setenv("MMEQ_REPORT_DIR", str(tmp_path / "empty"))
+
+        catalog = tmp_path / "catalog.csv"
+        _synthetic_catalog().to_csv(catalog, index=False)
+        out = tmp_path / "out"
+
+        cmd_report(_report_args(catalog, out))
+
+        risk_csv = out / "dam_risk_scores.csv"
+        assert risk_csv.exists(), "report must produce dam_risk_scores.csv"
+        risk = pd.read_csv(risk_csv)
+        assert len(risk) > 0
+        assert {"name", "pga_g", "composite_risk", "risk_grade"} <= set(risk.columns)
+        assert set(risk["risk_grade"]) <= {"Critical", "High", "Moderate", "Low"}
+        # Output is sorted by composite risk, descending.
+        assert risk["composite_risk"].is_monotonic_decreasing
+
+    def test_report_reuses_precomputed_risk(self, tmp_path, monkeypatch):
+        """--reuse-risk loads report/dam_risk_scores.csv instead of recomputing."""
+        from mmeq.cli import cmd_report
+
+        monkeypatch.chdir(tmp_path)  # no dam geojson here: recompute would yield nothing
+
+        catalog = tmp_path / "catalog.csv"
+        _synthetic_catalog().to_csv(catalog, index=False)
+
+        report_dir = tmp_path / "prebuilt"
+        report_dir.mkdir()
+        monkeypatch.setenv("MMEQ_REPORT_DIR", str(report_dir))
+        precomputed = pd.DataFrame({
+            "name": ["Dam A", "Dam B"],
+            "latitude": [22.0, 21.0],
+            "longitude": [96.0, 95.0],
+            "pga_g": [0.42, 0.10],
+            "composite_risk": [8.0, 4.0],
+            "risk_grade": ["Critical", "Moderate"],
+        })
+        # Written after the catalog, so it is "fresh".
+        precomputed.to_csv(report_dir / "dam_risk_scores.csv", index=False)
+
+        out = tmp_path / "out"
+        cmd_report(_report_args(catalog, out, reuse_risk=True))
+
+        risk = pd.read_csv(out / "dam_risk_scores.csv")
+        # The exact synthetic rows prove reuse (a recompute could never make these).
+        assert list(risk["name"]) == ["Dam A", "Dam B"]
+        assert list(risk["risk_grade"]) == ["Critical", "Moderate"]
+
+    def test_stale_precomputed_risk_is_ignored(self, tmp_path, monkeypatch):
+        import os
+
+        from mmeq.cli import _load_precomputed_risk
+
+        report_dir = tmp_path / "prebuilt"
+        report_dir.mkdir()
+        monkeypatch.setenv("MMEQ_REPORT_DIR", str(report_dir))
+        risk_path = report_dir / "dam_risk_scores.csv"
+        pd.DataFrame({"name": ["X"], "risk_grade": ["Low"]}).to_csv(risk_path, index=False)
+
+        catalog = tmp_path / "catalog.csv"
+        _synthetic_catalog().to_csv(catalog, index=False)
+        # Make the risk CSV strictly older than the catalog.
+        old = os.path.getmtime(catalog) - 100
+        os.utime(risk_path, (old, old))
+
+        assert _load_precomputed_risk(str(catalog)) is None
+        # And a fresh one is returned.
+        os.utime(risk_path, None)
+        assert _load_precomputed_risk(str(catalog)) is not None


### PR DESCRIPTION
## Summary

Closes the remaining spec 003 items (P2, P4, P5):

- **P2 — dam risk computed once per CI build:** `mmeq report --reuse-risk` (or `MMEQ_REUSE_RISK=1`) loads the `dam_risk_scores.csv` that `tools/build_figure_data.py` already produced, with freshness + validity guards (falls back to computing). Wired into `report_and_pages.yml`.
- **P5 — config-sourced science constants:** `RISK_WEIGHTS`, `RISK_GRADE_THRESHOLDS`, `GMPE_SIGMA_LN` moved to `config.py` (MMEQ_*-overridable); shared `_component_scores`/`_grade` helpers deduplicate `dam_risk_scores` vs `sensitivity_analysis`; `scipy.stats.norm` import hoisted out of the PSHA inner loop.
- **P4 — tests:** 64 → **77 passing** (hazard-curve monotonicity + `catalog_years` scaling, fragility lognormal properties, grade boundaries, report smoke test, reuse/staleness tests).

## Scientific invariance (the key check)

Pure refactor: `dam_risk_scores.csv` and `sensitivity_analysis.csv` are **byte-identical** to pre-change baselines; grades exactly Critical 25 / High 148 / Moderate 67 / Low 14. `--reuse-risk` path logs the reuse and emits a byte-identical CSV.

ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)