### PR TITLE
fix: full-repo audit — atomic writes, HTTP timeouts, geocoder race, CI hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Review ownership (takes effect once branch protection requires code-owner
+# review). Later matches take precedence; the explicit entries below document
+# ownership of the published artifacts and CI config.
+* @akzedevops
+
+/quake_exports/ @akzedevops
+/docs/ @akzedevops
+/.github/ @akzedevops

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Weekly dependency update PRs for all three ecosystems in this repo.
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: gomod
+    directory: "/go"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/daily_data_fetch.yml
+++ b/.github/workflows/daily_data_fetch.yml
@@ -7,6 +7,13 @@ on:
 
 permissions:
   contents: write
+  issues: write   # failure-notification step files/updates an issue
+
+# Never run two fetches at once (overlapping pushes would race); queue instead
+# of cancelling so a manual dispatch doesn't kill the scheduled run mid-push.
+concurrency:
+  group: daily-fetch
+  cancel-in-progress: false
 
 jobs:
   fetch_and_update:
@@ -49,4 +56,25 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add quake_exports/
           git diff --cached --quiet || git commit -m "feat: Update earthquake data"
-          git push origin master
+          # master may have moved while the export ran (e.g. a PR merge or the
+          # report workflow's artifact commit) — rebase onto the new tip and
+          # retry so a non-fast-forward doesn't fail the whole run.
+          for i in 1 2 3; do
+            git push origin master && break
+            git pull --rebase origin master || exit 1
+          done
+
+      - name: Notify on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="Daily data fetch failed"
+          body="The scheduled earthquake data fetch failed. See the run log: $RUN_URL"
+          existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number' --repo "$GITHUB_REPOSITORY")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body" --repo "$GITHUB_REPOSITORY"
+          else
+            gh issue create --title "$title" --body "$body" --repo "$GITHUB_REPOSITORY"
+          fi

--- a/.github/workflows/daily_data_fetch.yml
+++ b/.github/workflows/daily_data_fetch.yml
@@ -58,11 +58,16 @@ jobs:
           git diff --cached --quiet || git commit -m "feat: Update earthquake data"
           # master may have moved while the export ran (e.g. a PR merge or the
           # report workflow's artifact commit) — rebase onto the new tip and
-          # retry so a non-fast-forward doesn't fail the whole run.
+          # retry so a non-fast-forward doesn't fail the whole run. The push
+          # result is tracked explicitly: with `push && break` alone, exhausting
+          # the retries would exit with the last REBASE's status (0), silently
+          # dropping the day's commit and never firing the failure notifier.
+          pushed=0
           for i in 1 2 3; do
-            git push origin master && break
+            if git push origin master; then pushed=1; break; fi
             git pull --rebase origin master || exit 1
           done
+          [ "$pushed" = 1 ] || { echo "push failed after 3 attempts"; exit 1; }
 
       - name: Notify on failure
         if: failure()

--- a/.github/workflows/report_and_pages.yml
+++ b/.github/workflows/report_and_pages.yml
@@ -12,15 +12,16 @@ on:
       - 'tools/build_figure_data.py'
       - 'paper/main.tex'
       - 'pyproject.toml'
+      - 'docs/index.html'
 
-permissions:
-  contents: write
-  pages: write
-  id-token: write
+# Least privilege: permissions are granted per job below (test: read;
+# build: contents write; deploy: pages + id-token write).
 
+# Queue Pages runs, never cancel a live deploy mid-flight (GitHub's Pages
+# template semantics).
 concurrency:
   group: "pages"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # Fixed timestamp so matplotlib/LaTeX embed a stable creation date — rebuilt
 # figures and the paper PDF then only differ in git when their content actually
@@ -31,6 +32,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -46,6 +49,8 @@ jobs:
   build:
     needs: test          # do not regenerate/deploy unless tests pass
     runs-on: ubuntu-latest
+    permissions:
+      contents: write    # commits regenerated report/figures/paper back to master
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -93,7 +98,7 @@ jobs:
           cp -f paper/figures/*.png docs/report/figures/
 
       - name: Build paper PDF
-        uses: xu-cheng/latex-action@v3
+        uses: xu-cheng/latex-action@e2f99d4b3685b0da93f97e1b86ad8fab81105098 # v3
         with:
           root_file: main.tex
           working_directory: paper
@@ -127,6 +132,10 @@ jobs:
     if: github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write       # deploy the Pages artifact
+      id-token: write    # OIDC token for actions/deploy-pages
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/report_and_pages.yml
+++ b/.github/workflows/report_and_pages.yml
@@ -112,11 +112,16 @@ jobs:
           git diff --cached --quiet || git commit -m "docs: update report, figures & paper [skip ci]"
           # master may have moved during the ~8 min build (e.g. a PR merge or the
           # daily data commit) — rebase the artifact commit onto the new tip and
-          # retry so a non-fast-forward doesn't fail the whole deploy.
+          # retry so a non-fast-forward doesn't fail the whole deploy. Track the
+          # push result explicitly: with `push && break` alone, exhausting the
+          # retries would exit with the last rebase's status (0), silently
+          # losing the artifact commit.
+          pushed=0
           for i in 1 2 3; do
-            git push origin master && break
+            if git push origin master; then pushed=1; break; fi
             git pull --rebase origin master || exit 1
           done
+          [ "$pushed" = 1 ] || { echo "push failed after 3 attempts"; exit 1; }
 
       - name: Setup Pages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/shadow_go_export.yml
+++ b/.github/workflows/shadow_go_export.yml
@@ -24,6 +24,7 @@ on:
 
 permissions:
   contents: read
+  issues: write   # failure-notification step files/updates an issue
 
 jobs:
   shadow:
@@ -87,3 +88,18 @@ jobs:
             /tmp/py_run
             /tmp/go_run
           retention-days: 7
+
+      - name: Notify on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="Shadow Go export parity diverged"
+          body="The Python/Go shadow export parity check failed. See the run log: $RUN_URL (re-run first — a benign validation-cutoff race can cause one-off failures; see the workflow header comment)."
+          existing=$(gh issue list --state open --search "in:title \"$title\"" --json number --jq '.[0].number' --repo "$GITHUB_REPOSITORY")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body" --repo "$GITHUB_REPOSITORY"
+          else
+            gh issue create --title "$title" --body "$body" --repo "$GITHUB_REPOSITORY"
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,3 +38,24 @@ jobs:
 
       - name: Run tests
         run: pytest tests/ -v
+
+  go-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go/go.mod
+          # stdlib-only module: no go.sum, so key the cache on go.mod
+          cache-dependency-path: go/go.mod
+
+      - name: Vet and test
+        run: |
+          cd go
+          go vet ./...
+          go test -race ./...

--- a/generate_figures.py
+++ b/generate_figures.py
@@ -242,7 +242,7 @@ fig, ax = plt.subplots(figsize=(8, 6))
 # (The previous inline pga_ask08 was the pre-v2 broken model: a1=-0.526, missing
 # the site/geometry terms — it disagreed with the pipeline that produces the
 # dam PGA scatter on this same figure.)
-from src.mmeq.analysis.dam_risk import estimate_pga_ask08 as pga_ask08
+from mmeq.analysis.dam_risk import estimate_pga_ask08 as pga_ask08
 
 dists = np.logspace(0, 2.8, 200)
 for mag, ls in [(7.7, "-"), (7.0, "--"), (6.5, "-."), (6.0, ":")]:
@@ -393,8 +393,8 @@ plt.close()
 print("Figure 9: Vs30 map")
 
 # ========== Figure 10: Hazard curves for representative dams ==========
-from src.mmeq.analysis.dam_risk import compute_hazard_curve
-from src.mmeq.analysis.seismology import b_value as calc_bval, decluster_catalog
+from mmeq.analysis.dam_risk import compute_hazard_curve
+from mmeq.analysis.seismology import b_value as calc_bval, decluster_catalog
 
 # PSHA rates from the declustered catalog (Poisson assumption) so the 2025
 # aftershock sequence doesn't bias the b-value and inflate the hazard.
@@ -444,7 +444,7 @@ plt.close()
 print("Figure 10: Hazard curves")
 
 # ========== Figure 11: Coulomb stress transfer map ==========
-from src.mmeq.analysis.coulomb import compute_coulomb_grid, compute_coulomb_at_dams, build_rupture_segments
+from mmeq.analysis.coulomb import compute_coulomb_grid, compute_coulomb_at_dams, build_rupture_segments
 
 logging.basicConfig(level=logging.INFO)
 
@@ -517,7 +517,7 @@ plt.close()
 print("Figure 11: Coulomb stress transfer")
 
 # ========== Figure 12: Dam fragility curves ==========
-from src.mmeq.analysis.fragility import (
+from mmeq.analysis.fragility import (
     generate_fragility_curves, damage_state_probabilities, DAMAGE_STATE_LABELS
 )
 
@@ -547,8 +547,8 @@ plt.close()
 print("Figure 12: Fragility curves")
 
 # ========== Figure 13: Monte Carlo PGA uncertainty ==========
-from src.mmeq.analysis.dam_risk import monte_carlo_pga
-from src.mmeq.analysis.seismology import b_value as calc_b2
+from mmeq.analysis.dam_risk import monte_carlo_pga
+from mmeq.analysis.seismology import b_value as calc_b2
 
 b_mc, a_mc, mc_mc = calc_b2(df["mag"], min_mag=4.0)
 

--- a/go/internal/api/client.go
+++ b/go/internal/api/client.go
@@ -34,11 +34,23 @@ const (
 // variable (not a const) so tests can shrink it.
 var backoffBase = 500 * time.Millisecond
 
+// defaultHTTPClient is the fallback when Client.HTTPClient is nil. Unlike
+// http.DefaultClient it has a finite Timeout, so a server that accepts a
+// connection and never responds cannot hang a fetch (and its worker goroutine)
+// forever. 60s is a whole-request bound chosen to cover the Python side's
+// REQUEST_TIMEOUT=(5,30) connect/read pair with slack for large 10000-record
+// pages, whose bodies can take a while to stream.
+var defaultHTTPClient = &http.Client{Timeout: 60 * time.Second}
+
+// maxPagesCeiling is an absolute upper bound on pages per fetchAll call, as a
+// last-resort guard against a pathological server; see fetchAll.
+const maxPagesCeiling = 1000
+
 // Client is a Myanmar Earthquake API v2 client. The zero value is not usable —
 // BaseURL is required; the other fields fall back to sane defaults when unset.
 type Client struct {
 	BaseURL    string       // e.g. "https://mmeq.akze.net" (no trailing path)
-	HTTPClient *http.Client // defaults to http.DefaultClient
+	HTTPClient *http.Client // defaults to a client with a 60s whole-request Timeout
 	PageLimit  int          // records per page; defaults to 10000 (the API max)
 	MaxRetries int          // retries after the first attempt; defaults to 3
 }
@@ -47,7 +59,7 @@ func (c *Client) httpClient() *http.Client {
 	if c.HTTPClient != nil {
 		return c.HTTPClient
 	}
-	return http.DefaultClient
+	return defaultHTTPClient
 }
 
 func (c *Client) pageLimit() int {
@@ -161,11 +173,14 @@ func (c *Client) FetchUpdatedAfter(ctx context.Context, since string) ([]map[str
 
 // fetchAll paginates limit/offset over the given filter params until meta.total is
 // exhausted, remapping each record. An empty page also terminates, as a guard
-// against a server that under-reports pages relative to total.
+// against a server that under-reports pages relative to total. A hard page cap —
+// (meta.total/limit)+2 pages, recomputed from the latest page's total, bounded by
+// an absolute ceiling of maxPagesCeiling — guards against a pathological server
+// that keeps returning non-empty pages with total > offset forever.
 func (c *Client) fetchAll(ctx context.Context, params url.Values) ([]map[string]any, error) {
 	limit := c.pageLimit()
 	var out []map[string]any
-	for offset := 0; ; {
+	for offset, pages := 0, 0; ; {
 		p := url.Values{}
 		for k, vs := range params {
 			p[k] = vs
@@ -183,6 +198,15 @@ func (c *Client) fetchAll(ctx context.Context, params url.Values) ([]map[string]
 		offset += len(page.Earthquakes)
 		if len(page.Earthquakes) == 0 || offset >= page.Meta.Total {
 			return out, nil
+		}
+		pages++
+		maxPages := page.Meta.Total/limit + 2
+		if maxPages > maxPagesCeiling {
+			maxPages = maxPagesCeiling
+		}
+		if pages >= maxPages {
+			return nil, fmt.Errorf("api: pagination did not terminate after %d pages (limit=%d, last meta.total=%d, offset=%d); server appears to be returning inconsistent pages",
+				pages, limit, page.Meta.Total, offset)
 		}
 	}
 }
@@ -240,7 +264,9 @@ func (c *Client) doRequest(ctx context.Context, u string) (page *apiPage, retrya
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		// Drain a snippet for the error, then discard so the connection is reusable.
+		// Read up to 512 bytes of the body as an error snippet. Any remainder is
+		// NOT drained — the deferred Close discards it, which may cost connection
+		// reuse for oversized error bodies (acceptable: errors are the rare path).
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		retryable := resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500
 		return nil, retryable, fmt.Errorf("api: HTTP %d from %s: %s", resp.StatusCode, u, strings.TrimSpace(string(snippet)))

--- a/go/internal/api/client_test.go
+++ b/go/internal/api/client_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -266,9 +268,9 @@ func TestNoRetryOn4xx(t *testing.T) {
 // (e) Context cancellation aborts an in-flight request without further retries.
 func TestContextCancellationAborts(t *testing.T) {
 	release := make(chan struct{})
-	var attempts int
+	var attempts atomic.Int32 // handler goroutine is still running when we read it
 	_, c := serve(t, func(w http.ResponseWriter, r *http.Request) {
-		attempts++
+		attempts.Add(1)
 		<-release // block until the test finishes; the client must not wait for us
 	})
 	t.Cleanup(func() { close(release) })
@@ -291,7 +293,91 @@ func TestContextCancellationAborts(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("FetchWindow did not return after context cancellation")
 	}
-	if attempts != 1 {
-		t.Errorf("attempts = %d, want 1 (no retry after cancellation)", attempts)
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("attempts = %d, want 1 (no retry after cancellation)", got)
+	}
+}
+
+// (f) A Client with no explicit HTTPClient must get a finite, non-zero timeout —
+// http.DefaultClient (Timeout 0) would hang forever on a server that accepts a
+// connection and never responds.
+func TestDefaultHTTPClientHasTimeout(t *testing.T) {
+	c := &Client{BaseURL: "http://unused.invalid"}
+	if got := c.httpClient().Timeout; got <= 0 {
+		t.Errorf("default httpClient().Timeout = %v, want > 0 (must not be http.DefaultClient)", got)
+	}
+}
+
+// A server that accepts and never responds must fail the fetch once the client
+// timeout elapses, rather than hanging the caller forever.
+func TestFetchWindowTimesOutOnSilentServer(t *testing.T) {
+	shrinkBackoff(t)
+	release := make(chan struct{})
+	_, c := serve(t, func(w http.ResponseWriter, r *http.Request) {
+		<-release // never respond; the client's Timeout must fire first
+	})
+	t.Cleanup(func() { close(release) })
+	c.HTTPClient = &http.Client{Timeout: 50 * time.Millisecond}
+	c.MaxRetries = 1
+
+	errc := make(chan error, 1)
+	go func() {
+		_, err := c.FetchWindow(context.Background(), "2026-06-01", "2026-06-30")
+		errc <- err
+	}()
+
+	select {
+	case err := <-errc:
+		if err == nil {
+			t.Fatal("want timeout error from silent server, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("FetchWindow hung on a silent server; client timeout did not fire")
+	}
+}
+
+// (g) Pagination must terminate against a lying server that keeps returning
+// non-empty pages with meta.total > offset forever. With the default limit the
+// per-page cap is total/limit+2 = 2 pages here.
+func TestFetchAllCapsPagesAgainstLyingServer(t *testing.T) {
+	var requests atomic.Int32
+	_, c := serve(t, func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		// Always one more record, with total forever ahead of offset.
+		writePage(w, []map[string]any{event(fmt.Sprintf("q%d", offset), "2026-06-01T02:21:31Z")},
+			offset+2, 10000, offset)
+	})
+
+	_, err := c.FetchWindow(context.Background(), "2026-06-01", "2026-06-30")
+	if err == nil {
+		t.Fatal("want pagination-cap error against lying server, got nil")
+	}
+	if !strings.Contains(err.Error(), "pagination did not terminate") {
+		t.Errorf("err = %v, want a descriptive pagination-cap error", err)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Errorf("requests = %d, want 2 (total/limit+2 pages with total barely ahead)", got)
+	}
+}
+
+// The absolute page ceiling bounds even a server whose meta.total is astronomically
+// large (so total/limit+2 would allow near-unbounded pages).
+func TestFetchAllAbsolutePageCeiling(t *testing.T) {
+	var requests atomic.Int32
+	_, c := serve(t, func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		writePage(w, []map[string]any{event(fmt.Sprintf("q%d", offset), "2026-06-01T02:21:31Z")},
+			1<<40, 1, offset) // total so large the formula exceeds the ceiling
+	})
+	c.PageLimit = 1
+
+	_, err := c.FetchWindow(context.Background(), "2026-06-01", "2026-06-30")
+	if err == nil {
+		t.Fatal("want pagination-cap error, got nil")
+	}
+	if got := requests.Load(); got != maxPagesCeiling {
+		t.Errorf("requests = %d, want %d (absolute page ceiling)", got, maxPagesCeiling)
 	}
 }

--- a/go/internal/catalog/writer.go
+++ b/go/internal/catalog/writer.go
@@ -266,6 +266,12 @@ func atomicWrite(path string, data []byte) error {
 		os.Remove(tmpName)
 		return err
 	}
+	// os.CreateTemp creates the file 0600, and that mode survives the rename —
+	// open the artifact up to the usual 0644 so other users/processes can read it.
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
 	if err := os.Rename(tmpName, path); err != nil {
 		os.Remove(tmpName)
 		return err

--- a/go/internal/geocoder/geocoder.go
+++ b/go/internal/geocoder/geocoder.go
@@ -369,6 +369,10 @@ func haversineKm(lat1, lon1, lat2, lon2 float64) float64 {
 	return earthRadiusKm * 2 * math.Asin(math.Min(1, math.Sqrt(a)))
 }
 
-// round1 reproduces Python's round(d, 1): round half to even (banker's
-// rounding), NOT math.Round's half-away-from-zero.
+// round1 approximates Python's round(d, 1) via round-half-to-even on d*10 (NOT
+// math.Round's half-away-from-zero). It is not exact decimal rounding: the d*10
+// float multiplication can create exact .5 ties that Python's decimal-aware
+// rounding does not see (e.g. inputs like 0.15 or 2.85 differ). It does match
+// Python on the golden set and on real haversine outputs, which is what the
+// parity tests pin down.
 func round1(d float64) float64 { return math.RoundToEven(d*10) / 10 }

--- a/src/mmeq/analysis/dam_risk.py
+++ b/src/mmeq/analysis/dam_risk.py
@@ -12,6 +12,27 @@ from mmeq.config import GMPE_SIGMA_LN, RISK_GRADE_THRESHOLDS, RISK_WEIGHTS
 logger = logging.getLogger(__name__)
 
 
+def _log_effective_risk_config() -> None:
+    """Report the effective risk configuration at compute time.
+
+    RISK_WEIGHTS / RISK_GRADE_THRESHOLDS / GMPE_SIGMA_LN are overridable via
+    MMEQ_* env vars, which silently changes published science — make the values
+    actually used loud in the logs, and warn (do not raise; the pipeline must
+    degrade gracefully) if the weights no longer sum to 1.
+    """
+    logger.info(
+        "Effective dam-risk config: weights=%s grade_thresholds=%s gmpe_sigma_ln=%s",
+        RISK_WEIGHTS, RISK_GRADE_THRESHOLDS, GMPE_SIGMA_LN,
+    )
+    weight_sum = sum(RISK_WEIGHTS.values())
+    if abs(weight_sum - 1.0) > 1e-6:
+        logger.warning(
+            "RISK_WEIGHTS sum to %.6f, not 1.0 — composite risk scores and "
+            "published grades will be skewed. Check MMEQ_RISK_W_* overrides.",
+            weight_sum,
+        )
+
+
 def _grade(composite: float) -> str:
     """Map a composite risk score to its published grade (thresholds in config)."""
     if composite >= RISK_GRADE_THRESHOLDS["critical"]:
@@ -461,6 +482,7 @@ def dam_risk_scores(
     a_val: float,
     mc: float,
 ) -> pd.DataFrame:
+    _log_effective_risk_config()
     dams_df = _load_dams_df()
     if dams_df is None or dams_df.empty:
         logger.warning("No dam data available")

--- a/src/mmeq/analysis/geocoder.py
+++ b/src/mmeq/analysis/geocoder.py
@@ -9,6 +9,7 @@ import json
 import logging
 import math
 import os
+import threading
 
 from shapely.geometry import Point, shape
 from shapely.strtree import STRtree
@@ -26,26 +27,35 @@ _place_tree = None
 _place_names = None
 _place_coords = None
 
+# cmd_export enriches from a thread pool; lazy init must be locked so a thread
+# can never observe a partially-initialized loader (e.g. _place_tree set while
+# _place_names is still None).
+_admin_lock = threading.Lock()
+_places_lock = threading.Lock()
+
 EARTH_R = 6371.0  # km
 
 
 def _load_admin(level, path):
     if level in _admin_cache:
         return _admin_cache[level]
-    if not os.path.exists(path):
-        logger.warning("Admin boundaries not found: %s", path)
-        _admin_cache[level] = ([], None, [])
+    with _admin_lock:
+        if level in _admin_cache:  # another thread loaded it while we waited
+            return _admin_cache[level]
+        if not os.path.exists(path):
+            logger.warning("Admin boundaries not found: %s", path)
+            _admin_cache[level] = ([], None, [])
+            return _admin_cache[level]
+        with open(path) as f:
+            data = json.load(f)
+        names = []
+        geoms = []
+        for feat in data["features"]:
+            names.append(feat["properties"]["shapeName"])
+            geoms.append(shape(feat["geometry"]))
+        tree = STRtree(geoms)
+        _admin_cache[level] = (names, tree, geoms)
         return _admin_cache[level]
-    with open(path) as f:
-        data = json.load(f)
-    names = []
-    geoms = []
-    for feat in data["features"]:
-        names.append(feat["properties"]["shapeName"])
-        geoms.append(shape(feat["geometry"]))
-    tree = STRtree(geoms)
-    _admin_cache[level] = (names, tree, geoms)
-    return _admin_cache[level]
 
 
 def _query_admin(lat, lon, level, path):
@@ -64,32 +74,38 @@ def _load_places():
     global _place_tree, _place_names, _place_coords
     if _place_tree is not None:
         return
-    if not os.path.exists(_PLACES_PATH):
-        logger.warning("Places file not found: %s", _PLACES_PATH)
-        _place_tree = _place_names = _place_coords = None
-        return
+    with _places_lock:
+        if _place_tree is not None:  # another thread loaded it while we waited
+            return
+        if not os.path.exists(_PLACES_PATH):
+            logger.warning("Places file not found: %s", _PLACES_PATH)
+            _place_names = _place_coords = None
+            _place_tree = None
+            return
 
-    import numpy as np
-    from scipy.spatial import cKDTree
+        from scipy.spatial import cKDTree
 
-    coords = []
-    names = []
-    latlons = []
-    with open(_PLACES_PATH, newline="", encoding="utf-8") as f:
-        for row in csv.DictReader(f):
-            lat, lon = float(row["lat"]), float(row["lon"])
-            name = row["name_en"] or row["name"]
-            rlat, rlon = math.radians(lat), math.radians(lon)
-            coords.append((math.cos(rlat) * math.cos(rlon),
-                           math.cos(rlat) * math.sin(rlon),
-                           math.sin(rlat)))
-            names.append((name, row["place"]))
-            latlons.append((lat, lon))
+        coords = []
+        names = []
+        latlons = []
+        with open(_PLACES_PATH, newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                lat, lon = float(row["lat"]), float(row["lon"])
+                name = row["name_en"] or row["name"]
+                rlat, rlon = math.radians(lat), math.radians(lon)
+                coords.append((math.cos(rlat) * math.cos(rlon),
+                               math.cos(rlat) * math.sin(rlon),
+                               math.sin(rlat)))
+                names.append((name, row["place"]))
+                latlons.append((lat, lon))
 
-    _place_tree = cKDTree(coords)
-    _place_names = names
-    _place_coords = latlons
-    logger.info("Loaded %d OSM places for geocoding", len(names))
+        tree = cKDTree(coords)
+        # Assign the guard variable (_place_tree) LAST: unlocked fast-path
+        # readers that pass the guard must see fully-populated companions.
+        _place_names = names
+        _place_coords = latlons
+        _place_tree = tree
+        logger.info("Loaded %d OSM places for geocoding", len(names))
 
 
 def _haversine_km(lat1, lon1, lat2, lon2):

--- a/src/mmeq/cli.py
+++ b/src/mmeq/cli.py
@@ -15,6 +15,7 @@ from mmeq.export.writer import (
     save_to_json,
     load_combined_json,
     merge_combined_json,
+    save_combined_json,
     rebuild_combined,
 )
 from mmeq.analysis.temporal import (
@@ -131,9 +132,7 @@ def cmd_export(args) -> None:
     existing_records = load_combined_json(combined_json)
     new_records = combined_df.to_dict(orient="records")
     merged = merge_combined_json(existing_records, new_records)
-    with open(combined_json, "w", encoding="utf-8") as f:
-        import json
-        json.dump({"earthquakes": merged}, f, indent=2, ensure_ascii=False)
+    save_combined_json(merged, combined_json)
 
     logging.info("All done! Earthquake data is up to date!")
     if has_error:

--- a/src/mmeq/export/fetcher.py
+++ b/src/mmeq/export/fetcher.py
@@ -25,6 +25,11 @@ from requests.adapters import HTTPAdapter
 
 logger = logging.getLogger(__name__)
 
+# Hard cap on v2 pagination requests per window (10M records at the 10k page
+# size). A pathological server that keeps advertising more data than it serves
+# must raise instead of looping forever.
+MAX_V2_PAGES = 1000
+
 
 def _build_session() -> requests.Session:
     session = requests.Session()
@@ -104,7 +109,15 @@ def _fetch_v2(from_date: str, to_date: str) -> pd.DataFrame:
     ).strftime("%Y-%m-%d")
 
     records, offset, limit = [], 0, 10000
+    pages = 0
     while True:
+        if pages >= MAX_V2_PAGES:
+            raise ValueError(
+                f"v2 pagination exceeded {MAX_V2_PAGES} pages for "
+                f"{from_date} -> {to_date}; server keeps advertising more data "
+                "than it serves (runaway meta.total?)"
+            )
+        pages += 1
         response = get_session().get(
             f"{API_V2_URL}/export",
             params={"from": from_date, "to": to_exclusive, "limit": limit, "offset": offset},
@@ -116,7 +129,8 @@ def _fetch_v2(from_date: str, to_date: str) -> pd.DataFrame:
         if not isinstance(batch, list):
             raise ValueError("v2 response 'earthquakes' is not a list")
         records.extend(batch)
-        total = payload.get("meta", {}).get("total", len(records))
+        # "meta": null must not crash the fetch — fall back to len(records).
+        total = (payload.get("meta") or {}).get("total", len(records))
         offset += len(batch)
         if offset >= total or not batch:
             break

--- a/src/mmeq/export/writer.py
+++ b/src/mmeq/export/writer.py
@@ -81,6 +81,9 @@ def _atomic_write(path: str, write_fn) -> None:
     os.close(fd)
     try:
         write_fn(tmp)
+        # mkstemp creates 0600 temp files and os.replace preserves the mode;
+        # match the 0644 the repo's committed data files use.
+        os.chmod(tmp, 0o644)
         os.replace(tmp, path)
     except Exception:
         if os.path.exists(tmp):
@@ -146,6 +149,17 @@ def save_to_json(df: pd.DataFrame, path: str) -> None:
     if df.empty:
         return
     payload = {"earthquakes": df.to_dict(orient="records")}
+    _atomic_write(path, lambda p: _dump_json(payload, p))
+
+
+def save_combined_json(records: List[dict], path: str) -> None:
+    """Atomically write the combined-JSON store ({"earthquakes": records}).
+
+    Must go through _atomic_write: a truncated combined JSON is silently treated
+    as empty by load_combined_json, which would erase the accumulated history on
+    the next merge.
+    """
+    payload = {"earthquakes": records}
     _atomic_write(path, lambda p: _dump_json(payload, p))
 
 

--- a/tests/test_dam_risk.py
+++ b/tests/test_dam_risk.py
@@ -152,6 +152,50 @@ class TestConfigSourcedScoring:
         assert _grade(RISK_GRADE_THRESHOLDS["moderate"] - 0.01) == "Low"
 
 
+class TestEffectiveConfigLogging:
+    """Env overrides silently change published science — the compute entry point
+    (dam_risk_scores) logs the effective config and warns on bad weights."""
+
+    def test_warns_when_weights_do_not_sum_to_one(self, monkeypatch, caplog):
+        import logging
+
+        import mmeq.analysis.dam_risk as dam_risk
+
+        monkeypatch.setattr(dam_risk, "RISK_WEIGHTS", {
+            "seismic": 0.35, "fault": 0.30, "proximity": 0.20, "exposure": 0.30
+        })
+        with caplog.at_level(logging.INFO, logger="mmeq.analysis.dam_risk"):
+            dam_risk._log_effective_risk_config()
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, "bad weights must produce exactly one WARNING"
+        assert "1.15" in warnings[0].getMessage()
+        assert "MMEQ_RISK_W_" in warnings[0].getMessage()
+
+    def test_no_warning_for_default_weights(self, caplog):
+        import logging
+
+        import mmeq.analysis.dam_risk as dam_risk
+
+        with caplog.at_level(logging.INFO, logger="mmeq.analysis.dam_risk"):
+            dam_risk._log_effective_risk_config()
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+        # And the effective config is reported at INFO for observability.
+        infos = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+        assert any("Effective dam-risk config" in m for m in infos)
+
+    def test_entry_point_calls_config_logging(self, monkeypatch, caplog):
+        import logging
+
+        import mmeq.analysis.dam_risk as dam_risk
+
+        # No dam data -> early return, but the config line must already be out.
+        monkeypatch.setattr(dam_risk, "_load_dams_df", lambda: None)
+        with caplog.at_level(logging.INFO, logger="mmeq.analysis.dam_risk"):
+            out = dam_risk.dam_risk_scores(_synthetic_catalog(), 1.0, 5.0, 4.0)
+        assert out.empty
+        assert any("Effective dam-risk config" in r.getMessage() for r in caplog.records)
+
+
 def _synthetic_catalog(n: int = 60) -> pd.DataFrame:
     """Tiny plausible Myanmar catalog with one dominant M7.7 event."""
     rng = np.random.RandomState(0)

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -2,6 +2,7 @@
 from datetime import date, timedelta
 
 import pandas as pd
+import pytest
 
 import mmeq.export.fetcher as fetcher
 
@@ -160,6 +161,48 @@ def test_v2_pagination_uses_multiple_calls(monkeypatch):
     assert len(df) == 12000
     assert df["id"].nunique() == 12000, "pages must union without duplication"
     assert len(fake.calls) == 2, "meta.total must drive exactly two 10k pages"
+
+
+def test_v2_meta_null_does_not_crash(monkeypatch):
+    # The API may serve "meta": null; the fetch must fall back to the batch
+    # length instead of raising AttributeError on None.get(...).
+    class _MetaNullSession:
+        def get(self, url, params=None, timeout=None):
+            return _FakeResp({
+                "meta": None,
+                "earthquakes": [_raw_v1_record("a1"), _raw_v1_record("a2")],
+            })
+
+    monkeypatch.setattr(fetcher, "API_V2_URL", "https://mmeq.example/api/v2")
+    monkeypatch.setattr(fetcher, "get_session", lambda: _MetaNullSession())
+
+    df = fetcher.fetch_quake_data("2026-06-01", "2026-06-02")
+    assert sorted(df["id"]) == ["a1", "a2"]
+
+
+def test_v2_runaway_server_raises_instead_of_looping(monkeypatch):
+    # A pathological server that keeps returning non-empty pages with
+    # total > offset must trip the page cap, not loop forever.
+    class _RunawaySession:
+        def __init__(self):
+            self.calls = 0
+
+        def get(self, url, params=None, timeout=None):
+            self.calls += 1
+            offset = int(params["offset"])
+            return _FakeResp({
+                "meta": {"total": offset + 10},  # always advertises more
+                "earthquakes": [_raw_v1_record(f"r{offset}")],
+            })
+
+    fake = _RunawaySession()
+    monkeypatch.setattr(fetcher, "API_V2_URL", "https://mmeq.example/api/v2")
+    monkeypatch.setattr(fetcher, "get_session", lambda: fake)
+    monkeypatch.setattr(fetcher, "MAX_V2_PAGES", 7)
+
+    with pytest.raises(ValueError, match="exceeded 7 pages"):
+        fetcher.fetch_quake_data("2026-06-01", "2026-06-02")
+    assert fake.calls == 7, "must stop exactly at the page cap"
 
 
 def test_v1_path_when_v2_disabled(monkeypatch):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -5,10 +5,19 @@ in full each run and must be overwritten, not appended.
 """
 import json
 import os
+import stat
 
 import pandas as pd
+import pytest
 
-from mmeq.export.writer import save_to_csv, merge_combined_json, rebuild_combined
+import mmeq.export.writer as writer
+from mmeq.export.writer import (
+    load_combined_json,
+    merge_combined_json,
+    rebuild_combined,
+    save_combined_json,
+    save_to_csv,
+)
 
 
 def _frame(ids):
@@ -84,3 +93,50 @@ def test_atomic_write_leaves_no_tmp(tmp_path):
     save_to_csv(_frame(["a", "b"]), path, overwrite=True)
     assert os.path.exists(path)
     assert not any(f.endswith(".tmp") for f in os.listdir(tmp_path)), "no temp file left behind"
+
+
+def test_atomic_write_produces_world_readable_file(tmp_path):
+    # mkstemp creates 0600 temps and os.replace preserves the mode; the final
+    # file must be 0644 like the repo's committed data files.
+    path = str(tmp_path / "out.csv")
+    save_to_csv(_frame(["a"]), path, overwrite=True)
+    assert stat.S_IMODE(os.stat(path).st_mode) == 0o644
+
+
+def test_save_combined_json_round_trips(tmp_path):
+    # The combined JSON must round-trip through the reader and use the exact
+    # _dump_json envelope/formatting shared by every other JSON writer.
+    path = str(tmp_path / "earthquakes_combined.json")
+    records = [
+        {"id": "a", "time_utc": "2025-05-01 00:00:00", "mag": 5.0, "location": "မန္တလေး"},
+        {"id": "b", "time_utc": "2025-05-02 00:00:00", "mag": 4.2, "location": "Sagaing"},
+    ]
+    save_combined_json(records, path)
+
+    assert load_combined_json(path) == records
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+    expected = json.dumps({"earthquakes": records}, indent=2, ensure_ascii=False)
+    assert content == expected, "must match the _dump_json formatting used elsewhere"
+    assert "မန္တလေး" in content, "ensure_ascii=False must be preserved"
+    assert not any(f.endswith(".tmp") for f in os.listdir(tmp_path))
+
+
+def test_save_combined_json_is_atomic(tmp_path, monkeypatch):
+    # A crash mid-write must leave the previous combined JSON intact: a
+    # truncated file parses as [] in load_combined_json and would silently
+    # erase the accumulated history on the next merge.
+    path = str(tmp_path / "earthquakes_combined.json")
+    save_combined_json([{"id": "a", "mag": 5.0}], path)
+
+    def exploding_dump(payload, p):
+        with open(p, "w", encoding="utf-8") as f:
+            f.write('{"earthquakes": [{"id":')  # truncated garbage
+        raise OSError("disk full")
+
+    monkeypatch.setattr(writer, "_dump_json", exploding_dump)
+    with pytest.raises(OSError):
+        save_combined_json([{"id": "b", "mag": 6.0}], path)
+
+    assert load_combined_json(path) == [{"id": "a", "mag": 5.0}], "history preserved"
+    assert not any(f.endswith(".tmp") for f in os.listdir(tmp_path)), "temp cleaned up"

--- a/tools/backfill.py
+++ b/tools/backfill.py
@@ -30,11 +30,12 @@ from datetime import date, timedelta
 import pandas as pd
 from dateutil.relativedelta import relativedelta
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+# Allow running without installing the package (mmeq lives under src/).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from src.mmeq.config import EXPORT_DIR
-from src.mmeq.export.fetcher import fetch_quake_data_complete
-from src.mmeq.export.writer import save_to_csv, save_to_json, validate_quake_data
+from mmeq.config import EXPORT_DIR
+from mmeq.export.fetcher import fetch_quake_data_complete
+from mmeq.export.writer import save_to_csv, save_to_json, validate_quake_data
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 log = logging.getLogger("backfill")

--- a/tools/build_figure_data.py
+++ b/tools/build_figure_data.py
@@ -23,12 +23,12 @@ import sys
 
 import pandas as pd
 
-# Allow running from the repo root without installing the package.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+# Allow running without installing the package (mmeq lives under src/).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from src.mmeq.analysis.dam_risk import _load_dams_df, dam_risk_scores, sensitivity_analysis
-from src.mmeq.analysis.osm_exposure import _get_vs30
-from src.mmeq.analysis.seismology import b_value, decluster_catalog
+from mmeq.analysis.dam_risk import _load_dams_df, dam_risk_scores, sensitivity_analysis
+from mmeq.analysis.osm_exposure import _get_vs30
+from mmeq.analysis.seismology import b_value, decluster_catalog
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 log = logging.getLogger("build_figure_data")


### PR DESCRIPTION
A 4-agent audit (architecture / CI-CD / code correctness / security) of the whole repo, with every finding verified before fixing. Highlights:

**Real bugs fixed**
- The daily CI's combined-JSON write was the one non-atomic write in the pipeline — and a truncated file silently **erases all JSON history** on the next run. Now atomic via `writer.save_combined_json` (+ crash-simulation test).
- The Go exporter had **no HTTP timeout anywhere** (http.DefaultClient); a hung API stalls the daily run forever. Now a 60s default (+ silent-server test).
- Geocoder lazy-init race under the 10-thread export pool could silently drop the 6 geocode columns for a month (locks + guard-assigned-last).

**Hardening**: fetcher meta-null crash, pagination caps (both languages), 0644 artifact modes, dam-risk config logging + weight-sum warning, `go test -race` green.

**CI/CD**: Go tests now gate PRs; daily-fetch push gets the rebase-retry loop + concurrency guard; failures open GitHub issues; Pages deploys can't be cancelled mid-flight; per-job least-privilege permissions; `docs/index.html` finally in the deploy paths; latex-action SHA-pinned; dependabot + CODEOWNERS added.

**Audit verdicts** (full reports in session): no secrets/IPs leaked, no injectable workflows, architecture layering clean (no cycles, writer centralization verified). Deferred items listed in the PR comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)