### PR TITLE
chore(ci): finish node24 action migration (pairs deploy-pages v5 with upload v5)

### DIFF
--- a/.github/workflows/daily_data_fetch.yml
+++ b/.github/workflows/daily_data_fetch.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/report_and_pages.yml
+++ b/.github/workflows/report_and_pages.yml
@@ -35,8 +35,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Install & test
@@ -53,12 +53,12 @@ jobs:
       contents: write    # commits regenerated report/figures/paper back to master
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -125,7 +125,7 @@ jobs:
 
       - name: Setup Pages
         if: github.ref == 'refs/heads/master'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/master'
@@ -147,4 +147,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/shadow_go_export.yml
+++ b/.github/workflows/shadow_go_export.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -45,7 +45,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
Completes the Dependabot batch: `checkout@v7`, `setup-python@v6`, `configure-pages@v6`, and `deploy-pages@v5` — the latter is required for compatibility with `upload-pages-artifact@v5` merged in #28 (both are v5-generation artifact format). No node20-runtime actions remain in any workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)