### PR TITLE
docs: refresh CLAUDE.md + spec index to post-migration reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,25 +18,27 @@ ground-motion math matters more than anything else — see "Domain correctness" 
 src/mmeq/                 # ← canonical v2 package (edit code here)
 ├── cli.py                # argparse entry point: export | analyze | visualize | report
 ├── config.py             # all constants + env-var overrides (MMEQ_*)
-├── export/               # fetcher.py (API + date ranges), writer.py (CSV/JSON, validate, dedup)
+├── export/               # fetcher.py (API + date ranges), writer.py (CSV/JSON, validate,
+│                         #   dedup), pipeline.py (run_export orchestration)
 ├── analysis/             # seismology, dam_risk (GMPE/Vs30/PSHA), clustering, aftershock,
 │                         #   coulomb, fragility, finite_fault, gem_faults, osm_exposure,
-│                         #   population[_raster], shakemap_validation, temporal, geocoder
+│                         #   population, shakemap_validation, temporal, geocoder
 └── visualization/        # map (Folium), dashboard (Plotly), cross_section (3D),
-                          #   animated_map, report (PDF)
+                          #   animated_map, report (PDF), assets.py + vendor/ (self-hosted
+                          #   JS/CSS — see tools/fetch_vendor.py + vendor_lock.json)
 
 go/                       # Go rewrite of the export pipeline ONLY (specs/002+004):
                           #   cmd/mmeq-export + internal/{api,catalog,config,export,geocoder};
                           #   golden-file tested for byte-parity with the Python writer —
                           #   run `cd go && go test ./...` when touching it
-tests/                    # pytest suite (80 tests): validation, dateranges, seismology,
-                          #   writer/fetcher, dam-risk scoring
+tests/                    # pytest suite (94 tests): validation, dateranges, seismology,
+                          #   writer/fetcher, dam-risk scoring, vendored assets
 tools/                    # diff_exports.py (Python-vs-Go tree diff), backfill.py,
-                          #   build_figure_data.py
+                          #   build_figure_data.py, fetch_vendor.py (+ vendor_lock.json)
 data/                     # input datasets: admin boundaries, shakemap, osm, faults, finite_fault
 quake_exports/            # generated earthquake CSV/JSON (csv|json × monthly|yearly|combined)
 docs/                     # GitHub Pages site + generated report/ artifacts
-paper/                    # LaTeX write-up (main.tex) + figures/ (13 figs, PDF+PNG)
+paper/                    # LaTeX write-up (main.tex) + figures/ (14 figs, PDF+PNG)
 .github/workflows/        # daily_data_fetch.yml, report_and_pages.yml, tests.yml,
                           #   shadow_go_export.yml (nightly Python-vs-Go parity diff)
 ```
@@ -45,7 +47,7 @@ The upstream API service lives in a separate PRIVATE repo (`akzedevops/mmeq-api`
 checked out at `~/mmeq-api`); its interactive docs are at https://mmeq.akze.net/docs.
 The export pipeline fetches `/api/v2/export` (full-fidelity raw records — see
 `specs/004`); the typed `/api/v2/earthquakes` route deliberately drops legacy columns
-and CANNOT reproduce the published 33-column artifact.
+and CANNOT reproduce the published 32-column artifact.
 
 ### Live root scripts
 
@@ -82,7 +84,7 @@ the Python `mmeq export` remains for local use and fetches the same paginated
 
 **CI gates on tests:** `report_and_pages.yml`'s deploy `needs:` a `test` job (ruff +
 pytest), and `tests.yml` runs on every PR/push — keep both green or the dashboard won't
-deploy. See `specs/001` (data-fetch) and `specs/003` (improvements) for the active roadmap.
+deploy. Specs 001–004 are Done; the active roadmap is `specs/005` (artifact schema v2, Draft).
 
 ## Conventions
 

--- a/specs/002-go-export-rewrite.md
+++ b/specs/002-go-export-rewrite.md
@@ -69,7 +69,8 @@ The mmeq API v2 (Go/SQLite, `github.com/akzedevops/mmeq-api`, private) is in pro
 The exporter has BOTH clients, but **defaults to the v1-compat route**
 (`MMEQ_FETCH_ROUTE=v1`): the typed `/api/v2/earthquakes` schema deliberately drops the
 raw upstream columns (`dmin`, `gap`, `nst`, `rms`, `shakemapURL`, `continent`, …) that
-make up the published 33-column artifact, and adds `ingested_at` — so a v2-fed export
+make up the published 33-column artifact (later corrected: the shipped header is
+**32** columns — `time` is dropped; see specs 004/005), and adds `ingested_at` — so a v2-fed export
 can never be byte-compatible. Discovered 2026-07-03 by the first full-tree diff; the
 same diff also caught a production bug where the v1-compat route alphabetized record
 keys (Go map marshal), which would have silently flipped pandas' CSV column order —
@@ -103,7 +104,7 @@ bounds (lat/lon/depth/mag) + NaN-drop; `time_utc` UTC `%Y-%m-%d %H:%M:%S` and `t
 Asia/Yangon (UTC+06:30, via tzdb not a hardcoded offset); `id`-keyed dedup `keep="last"`;
 combined-JSON merge keyed on id else `(time_utc,lat,lon)` preserving first-seen order;
 monthly = overwrite, yearly/combined = merge+dedup; date-range generation from
-`last_event + 1 day`; the 33-column CSV header/order ending in the 6 geocoder columns +
+`last_event + 1 day`; the 32-column CSV header/order (spec text originally said 33) ending in the 6 geocoder columns +
 `shakemapURL/shakemapLastUpdated`; JSON `{"earthquakes":[...]}` indent=2, UTF-8 literal
 (non-ASCII Myanmar names). **The Go port must also implement [[001-data-fetch-upgrade]]'s
 500-cap bisection and contract gate** — so 001 should land first as the reference.

--- a/specs/README.md
+++ b/specs/README.md
@@ -45,3 +45,4 @@ new spec from `TEMPLATE.md`, then drive steps 2–5 until every acceptance crite
 | [002](002-go-export-rewrite.md) | Rewrite the fetch/export CLI in Go (separate branch) | Done |
 | [003](003-project-improvements.md) | Project improvements — CI test gate, de-duplication, structure | Done |
 | [004](004-v2-export-migration.md) | Migrate the artifact pipeline to API v2 (`/api/v2/export`) | Done |
+| [005](005-artifact-schema-v2.md) | Artifact schema v2 — drop zero-information columns | Draft |


### PR DESCRIPTION
Pre-audit documentation sync (first step of the full integrity review):

- **CLAUDE.md**: 32-column artifact (was 33), 94 tests (was 80), 14 paper figures (was 13); layout now lists `export/pipeline.py`, `visualization/assets.py` + `vendor/`, `tools/fetch_vendor.py`; removed the deleted `population_raster`; roadmap pointer now says specs 001–004 Done / 005 Draft.
- **specs/README.md**: index gains the 005 (artifact schema v2, Draft) row.
- **specs/002**: the two historical "33-column" statements annotated with the 32-column correction established by spec 004.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)