### PR TITLE
fix(science): scenario event = 2025 Sagaing (not 1988 Lancang); Omori fit = Ogata MLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+### Scientific corrections (2026-07-06 integrity audit, phase 1)
+
+- **Scenario event fixed: 2025 Sagaing, not 1988 Lancang.** The catalog holds
+  two M7.7 events and every scenario consumer (`dam_risk_scores`,
+  `monte_carlo_pga`, `sensitivity_analysis`, the Omori aftershock forecast)
+  selected the maximum-magnitude event with a bare `nlargest`/`idxmax`, which
+  tie-breaks to the *first* row — the 1988-11-06 Lancang-Gengma earthquake on
+  the China border, ~400 km from the epicenter the README/paper describe. A
+  shared `seismology.select_scenario_event` now breaks magnitude ties by
+  recency (override: `MMEQ_SCENARIO_EVENT_ID`). Published dam grades change
+  from 25/148/67/14 (Critical/High/Moderate/Low) to **45/134/61/14** —
+  179 dams (70%) Critical or High.
+- **Omori fit rewritten as Ogata (1983) maximum likelihood** on exact event
+  times. The previous least-squares fit on log-binned counts underestimated
+  p by 0.2–0.4 on synthetic catalogs (and pinned at its silent p=0.5 clip on
+  the real 2025 sequence) while hardcoding c=0.1 h. The 2025 M7.7 sequence now
+  fits K≈35, c≈16.4 h, p≈0.77; a synthetic-recovery regression test asserts
+  |p_fit − p_true| < 0.1. Previously published p=0.93 was the 1988 event's
+  biased fit.
+- **Paper sensitivity claim corrected**: "Critical+High stays above 30%
+  regardless of weights" was contradicted by the shipped artifact; the paper
+  now reports the actual distribution (median ~73%, 22/100 draws below 30%).
+- Stale "54% Critical or High" in the paper (a pre-GMPE-fix leftover) fixed
+  to 70% alongside the regenerated grade table.
+
 ### Go export cutover (specs 001/002/004 complete)
 
 The daily data-fetch CI now runs the Go `mmeq-export` binary (build ~seconds,

--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ I validated the GMPE against the actual Naypyidaw ShakeMap recording — predict
 
 | Grade | Count |
 |---|---|
-| Critical | 25 |
-| High | 148 |
-| Moderate | 67 |
+| Critical | 45 |
+| High | 134 |
+| Moderate | 61 |
 | Low | 14 |
 
-173 dams (68%) scored Critical or High. (Earlier versions under-counted these because a ground-motion bug floored the PGA of dams beyond ~100 km from the rupture, mis-grading them as Low — see CHANGELOG.)
+179 dams (70%) scored Critical or High. (Earlier versions under-counted these because a ground-motion bug floored the PGA of dams beyond ~100 km from the rupture, and until recently the scenario picked the wrong M7.7 — the catalog holds two, and the 1988 Lancang event tie-broke ahead of the 2025 Sagaing mainshock — see CHANGELOG.)
 
 ## How the Seismology Works
 
@@ -149,7 +149,7 @@ The catalog has 9,390 events. Most are small (mean M 3.2), but there are 6 event
 
 **Clustering:** DBSCAN in UTM Zone 47N coordinates (so distances are in meters, not degrees) identifies 7 seismic zones. The central Myanmar cluster contains 95% of all events.
 
-**Aftershock forecasting:** Modified Omori law fitted to the M7.7 sequence gives p = 0.93 (close to the global average of ~1.0), forecasting expected M≥3 aftershocks at 7, 30, and 90 day windows.
+**Aftershock forecasting:** Modified Omori law fitted by maximum likelihood (Ogata 1983) to the 2025 M7.7 Sagaing sequence gives p ≈ 0.77 with c ≈ 16 h — a slow decay, partly reflecting early-sequence catalog incompleteness after the mainshock — forecasting expected M≥3 aftershocks at 7, 30, and 90 day windows. (Earlier releases quoted p = 0.93 from a biased least-squares fit that had also selected the 1988 Lancang M7.7 as the mainshock.)
 
 **Coulomb stress transfer:** Using the USGS finite fault model (530 slip patches, 0–7 m variable slip), I computed which dams are in stress-triggered zones (34 dams, 13%) vs stress shadows (163 dams, 64%).
 

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -219,7 +219,7 @@ Each dam gets a composite score (0--10) from four components:
     R = 0.35 \times S_{seismic} + 0.30 \times S_{fault} + 0.20 \times S_{proximity} + 0.15 \times S_{exposure}
 \end{equation}
 
-where $S_{seismic}$ is PGA-based, $S_{fault}$ is distance to nearest fault, $S_{proximity}$ is distance to the M7.7 epicenter, and $S_{exposure}$ accounts for dam height/capacity/storage.
+where $S_{seismic}$ is PGA-based, $S_{fault}$ is distance to nearest fault, $S_{proximity}$ is distance to the 2025 M7.7 epicenter, and $S_{exposure}$ accounts for dam height/capacity/storage.
 
 \subsection{Results}
 
@@ -232,15 +232,15 @@ With the corrected GMPE:
 \toprule
 \textbf{Grade} & \textbf{Count} & \textbf{\%} \\
 \midrule
-Critical ($\geq 7$) & 25 & 9.8\% \\
-High (5--7) & 148 & 58.3\% \\
-Moderate (3--5) & 67 & 26.4\% \\
+Critical ($\geq 7$) & 45 & 17.7\% \\
+High (5--7) & 134 & 52.8\% \\
+Moderate (3--5) & 61 & 24.0\% \\
 Low ($< 3$) & 14 & 5.5\% \\
 \bottomrule
 \end{tabular}
 \end{table}
 
-So about 54\% of dams are Critical or High risk.
+So about 70\% of dams are Critical or High risk.
 The spatial pattern (Figure~\ref{fig:risk_map}) is clear: the highest-risk dams line up along the Sagaing Fault.
 
 \begin{figure}[htbp]
@@ -253,7 +253,7 @@ The spatial pattern (Figure~\ref{fig:risk_map}) is clear: the highest-risk dams 
 \subsection{Sensitivity to Weights}
 
 The weights (0.35/0.30/0.20/0.15) are somewhat arbitrary, so I ran 100 Monte Carlo iterations with random Dirichlet-sampled weights.
-The Critical+High fraction stays above 30\% regardless of weights, so the overall conclusion is robust.
+The median Critical+High fraction across draws is $\sim$73\%, but the grading is genuinely weight-sensitive: 22 of the 100 draws fall below a 30\% Critical+High fraction (minimum $\sim$12\%, 5th percentile $\sim$17\%), typically when the proximity weight dominates. The headline conclusion---that a substantial fraction of the portfolio carries elevated risk---holds for the large majority of weightings, but the exact grade counts should be read as conditional on the chosen weights.
 
 \begin{figure}[htbp]
     \centering
@@ -391,7 +391,7 @@ Near-fault sites are systematically low because this was a supershear rupture, w
     Always check stability before trusting a b-value.
 
     \item \textbf{Over half of Myanmar's dams are in high-hazard zones.}
-    25 Critical + 148 High = 173 dams (68\%) with significant seismic exposure.
+    45 Critical + 134 High = 179 dams (70\%) with significant seismic exposure.
     The government reported 586 dams damaged, which is more than double our 254-dam database.
 
     \item \textbf{Open data makes this possible.}

--- a/src/mmeq/analysis/aftershock.py
+++ b/src/mmeq/analysis/aftershock.py
@@ -5,6 +5,8 @@ from typing import Tuple
 import numpy as np
 import pandas as pd
 
+from mmeq.analysis.seismology import select_scenario_event
+
 logger = logging.getLogger(__name__)
 
 
@@ -30,33 +32,53 @@ def omori_params(
     if len(dt_hours) < 5:
         return 0.0, 1.0, 0.0
 
-    # Log-spaced bins spanning the full observed range. The first bin edge must
-    # start at the earliest aftershock (often minutes after the mainshock), not
-    # a hardcoded t=1 h — Omori decay peaks early, and np.histogram silently
-    # drops everything below the lowest edge.
-    t_min = max(dt_hours.min(), 0.01)
-    t_max = max(dt_hours.max(), t_min * 10)
-    bins = np.logspace(np.log10(t_min), np.log10(t_max), 20)
-    counts, edges = np.histogram(dt_hours, bins=bins)
-    centers = np.sqrt(edges[:-1] * edges[1:])
+    # Maximum-likelihood fit of the modified Omori law rate(t) = K/(t+c)^p on
+    # the exact event times (Ogata 1983). The previous least-squares fit on
+    # log-binned counts is provably biased (underestimates p by 0.2-0.4 and K
+    # severalfold on synthetic catalogs) and hardcoded c.
+    #
+    # For fixed (c, p) the K that maximizes the likelihood over (0, T] is
+    # K_hat = N / A(c, p) with A = ((T+c)^(1-p) - c^(1-p)) / (1-p)
+    # (A = ln((T+c)/c) at p=1), giving the profile negative log-likelihood
+    # -(N ln(N/A) - p * sum(ln(t_i + c)) - N).
+    from scipy.optimize import minimize
 
-    mask = counts > 0
-    if mask.sum() < 3:
+    t_obs = np.sort(dt_hours)
+    T = window_days * 24.0
+    n = len(t_obs)
+
+    def _integral(c: float, p: float) -> float:
+        if abs(p - 1.0) < 1e-9:
+            return math.log((T + c) / c)
+        return ((T + c) ** (1.0 - p) - c ** (1.0 - p)) / (1.0 - p)
+
+    def _neg_loglik(x) -> float:
+        log_c, p = x
+        c = math.exp(log_c)
+        a = _integral(c, p)
+        if not np.isfinite(a) or a <= 0:
+            return 1e12
+        return -(n * math.log(n / a) - p * np.log(t_obs + c).sum() - n)
+
+    bounds = [(math.log(1e-3), math.log(1e3)), (0.2, 3.0)]
+    best = None
+    for c0 in (0.1, 1.0, 10.0):
+        for p0 in (0.8, 1.1, 1.5):
+            res = minimize(_neg_loglik, x0=[math.log(c0), p0],
+                           method="L-BFGS-B", bounds=bounds)
+            if res.success and (best is None or res.fun < best.fun):
+                best = res
+    if best is None:
+        logger.warning("Omori MLE did not converge")
         return 0.0, 1.0, 0.0
 
-    log_centers = np.log10(centers[mask])
-    log_rates = np.log10(counts[mask] / np.diff(edges)[mask])
+    c_param = math.exp(best.x[0])
+    p = float(best.x[1])
+    K = n / _integral(c_param, p)
+    if p <= bounds[1][0] + 1e-6 or p >= bounds[1][1] - 1e-6:
+        logger.warning("Omori p=%.2f sits at an optimizer bound — fit is suspect", p)
 
-    # rate(t) = K / (t + c)^p  ->  log10(rate) ≈ log10(K) - p*log10(t) for t >> c.
-    # Slope gives p; intercept gives K (events/hour at t=1 h), which uses the
-    # whole fit rather than a single bin's raw count.
-    coeffs = np.polyfit(log_centers, log_rates, 1)
-    p = max(0.5, min(2.0, -coeffs[0]))
-    K = 10 ** coeffs[1]
-    c_param = 0.1  # hours; typical Omori offset, small vs the fit window
-
-    total_aftershocks = len(aftershocks)
-    logger.info(f"Omori params: K={K:.1f}, c={c_param:.2f}h, p={p:.2f}, N={total_aftershocks}")
+    logger.info(f"Omori MLE params: K={K:.1f}, c={c_param:.2f}h, p={p:.2f}, N={n}")
     return K, c_param, p
 
 
@@ -91,7 +113,10 @@ def modified_omori_forecast(
     min_mag: float = 3.0,
 ) -> Tuple[pd.DataFrame, dict]:
     if mainshock_time is None:
-        mainshock = catalog.loc[catalog["mag"].idxmax()]
+        # Max-magnitude event with ties broken by recency (the catalog holds
+        # two M7.7s; a bare idxmax silently fits the 1988 Lancang event
+        # instead of the 2025 Sagaing mainshock).
+        mainshock = select_scenario_event(catalog)
         mainshock_time = mainshock["time_utc"]
         if isinstance(mainshock_time, str):
             mainshock_time = pd.Timestamp(mainshock_time)

--- a/src/mmeq/analysis/dam_risk.py
+++ b/src/mmeq/analysis/dam_risk.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import json
 
+from mmeq.analysis.seismology import select_scenario_event
 from mmeq.config import GMPE_SIGMA_LN, RISK_GRADE_THRESHOLDS, RISK_WEIGHTS
 
 logger = logging.getLogger(__name__)
@@ -451,7 +452,7 @@ def sensitivity_analysis(
         return pd.DataFrame()
 
     fault_segments = _load_fault_segments()
-    major_eq = eq_df.nlargest(1, "mag").iloc[0]
+    major_eq = select_scenario_event(eq_df)
     major_mag = major_eq["mag"]
     major_depth = major_eq["depth"]
     major_lat = major_eq["latitude"]
@@ -507,7 +508,7 @@ def dam_risk_scores(
 
     fault_segments = _load_fault_segments()
     vs30_map = _load_vs30()
-    major_eq = eq_df.nlargest(1, "mag").iloc[0]
+    major_eq = select_scenario_event(eq_df)
     major_mag = major_eq["mag"]
     major_depth = major_eq["depth"]
     major_lat = major_eq["latitude"]
@@ -599,7 +600,7 @@ def monte_carlo_pga(
 
     fault_segments = _load_fault_segments()
     vs30_map = _load_vs30()
-    major_eq = eq_df.nlargest(1, "mag").iloc[0]
+    major_eq = select_scenario_event(eq_df)
     major_mag = major_eq["mag"]
     major_depth = major_eq["depth"]
     major_lat = major_eq["latitude"]

--- a/src/mmeq/analysis/seismology.py
+++ b/src/mmeq/analysis/seismology.py
@@ -54,6 +54,35 @@ def magnitude_of_completeness(
     return round(mc, 1)
 
 
+def select_scenario_event(df: pd.DataFrame) -> pd.Series:
+    """
+    Select the scenario ("major") event for hazard analyses: the
+    maximum-magnitude event, breaking magnitude ties by recency.
+
+    The catalog contains two M7.7 events (1988-11-06 Lancang-Gengma on the
+    China border and the 2025-03-28 Sagaing mainshock); a bare
+    ``nlargest``/``idxmax`` tie-breaks to the earlier row and silently
+    selects the wrong earthquake. Set MMEQ_SCENARIO_EVENT_ID to pin an
+    explicit catalog id instead.
+    """
+    from mmeq import config
+
+    if config.SCENARIO_EVENT_ID and "id" in df.columns:
+        pinned = df[df["id"].astype(str) == config.SCENARIO_EVENT_ID]
+        if not pinned.empty:
+            return pinned.iloc[0]
+        logger.warning(
+            "MMEQ_SCENARIO_EVENT_ID=%s not found in catalog; "
+            "falling back to max-magnitude selection",
+            config.SCENARIO_EVENT_ID,
+        )
+    top = df[df["mag"] == df["mag"].max()]
+    times = pd.to_datetime(top["time_utc"], errors="coerce")
+    if times.notna().any():
+        return top.loc[times.idxmax()]
+    return top.iloc[-1]
+
+
 def b_value_stability(
     magnitudes: pd.Series,
     mc_range: np.ndarray = None,

--- a/src/mmeq/config.py
+++ b/src/mmeq/config.py
@@ -72,6 +72,13 @@ RISK_GRADE_THRESHOLDS = {
 # the Cornell-McGuire PSHA integration and the Monte Carlo PGA simulation.
 GMPE_SIGMA_LN = float(os.environ.get("MMEQ_GMPE_SIGMA_LN", "0.65"))
 
+# Pin the scenario ("major") event used by dam-risk scoring and the aftershock
+# forecast to an explicit catalog id. When unset, the maximum-magnitude event
+# is used with ties broken by recency — the catalog contains two M7.7 events
+# (1988-11-06 Lancang and 2025-03-28 Sagaing) and a bare max() picks the
+# earlier, wrong one.
+SCENARIO_EVENT_ID = os.environ.get("MMEQ_SCENARIO_EVENT_ID", "")
+
 FAULT_LINES_PATH = os.environ.get("MMEQ_FAULT_LINES", "fault_lines.json")
 
 # --- Data files (config consolidation, audit M4/M5) -------------------------

--- a/tests/test_aftershock.py
+++ b/tests/test_aftershock.py
@@ -33,3 +33,28 @@ def test_first_hour_aftershocks_are_used():
 def test_too_few_events_returns_sentinel():
     catalog, t0 = _sequence([2.0, 5.0])  # only 2 aftershocks
     assert omori_params(t0, catalog, min_mag=3.0) == (0.0, 1.0, 0.0)
+
+
+def test_mle_recovers_synthetic_omori_parameters():
+    # Simulate an inhomogeneous Poisson process with known (K, c, p) by
+    # inverting the cumulative intensity, then require the MLE to recover p
+    # within 0.1 — the binned least-squares fit this replaced was off by
+    # 0.2-0.4 (audit finding, Ogata 1983).
+    K_true, c_true, p_true = 100.0, 2.0, 1.1
+    T = 30 * 24.0
+    rng = np.random.default_rng(42)
+
+    def cum(t):
+        return K_true * ((t + c_true) ** (1 - p_true) - c_true ** (1 - p_true)) / (1 - p_true)
+
+    def inv(y):
+        return (y * (1 - p_true) / K_true + c_true ** (1 - p_true)) ** (1 / (1 - p_true)) - c_true
+
+    n = rng.poisson(cum(T))
+    times_h = np.sort(inv(rng.uniform(0, cum(T), n)))
+    catalog, t0 = _sequence(times_h[times_h > 0])
+
+    K, c, p = omori_params(t0, catalog, window_days=30, min_mag=3.0)
+    assert abs(p - p_true) < 0.1
+    assert abs(c - c_true) < 1.5
+    assert 0.5 * K_true < K < 2.0 * K_true

--- a/tests/test_seismology.py
+++ b/tests/test_seismology.py
@@ -145,3 +145,66 @@ class TestGardnerKnopoffWindows:
         })
         result = decluster_catalog(df, window_days=30.0, distance_km=50.0)
         assert len(result) == 2
+
+
+class TestSelectScenarioEvent:
+    """Regression: the catalog holds two M7.7s (1988 Lancang, 2025 Sagaing);
+    tie-break must pick the most recent, not the first row."""
+
+    @pytest.fixture
+    def two_m77_catalog(self):
+        return pd.DataFrame({
+            "id": ["us1988lancang", "mid1", "us2025sagaing"],
+            "time_utc": ["1988-11-06 13:03:19", "2000-01-01 00:00:00", "2025-03-28 06:20:52"],
+            "latitude": [22.789, 20.0, 21.996],
+            "longitude": [99.611, 96.0, 95.926],
+            "depth": [17.6, 10.0, 10.0],
+            "mag": [7.7, 5.0, 7.7],
+        })
+
+    def test_tie_breaks_by_recency(self, two_m77_catalog):
+        from mmeq.analysis.seismology import select_scenario_event
+        ev = select_scenario_event(two_m77_catalog)
+        assert ev["id"] == "us2025sagaing"
+        assert ev["latitude"] == pytest.approx(21.996)
+
+    def test_tie_break_independent_of_row_order(self, two_m77_catalog):
+        from mmeq.analysis.seismology import select_scenario_event
+        shuffled = two_m77_catalog.iloc[[2, 0, 1]].reset_index(drop=True)
+        assert select_scenario_event(shuffled)["id"] == "us2025sagaing"
+
+    def test_single_max_unaffected(self, two_m77_catalog):
+        from mmeq.analysis.seismology import select_scenario_event
+        df = two_m77_catalog.copy()
+        df.loc[df["id"] == "us2025sagaing", "mag"] = 7.6
+        assert select_scenario_event(df)["id"] == "us1988lancang"
+
+    def test_env_pin_overrides(self, two_m77_catalog, monkeypatch):
+        from mmeq import config
+        from mmeq.analysis.seismology import select_scenario_event
+        monkeypatch.setattr(config, "SCENARIO_EVENT_ID", "mid1")
+        assert select_scenario_event(two_m77_catalog)["id"] == "mid1"
+
+    def test_env_pin_missing_falls_back(self, two_m77_catalog, monkeypatch):
+        from mmeq import config
+        from mmeq.analysis.seismology import select_scenario_event
+        monkeypatch.setattr(config, "SCENARIO_EVENT_ID", "nonexistent")
+        assert select_scenario_event(two_m77_catalog)["id"] == "us2025sagaing"
+
+    def test_omori_default_mainshock_uses_recent_tie(self, two_m77_catalog):
+        # cli.cmd_report hands the forecast a parsed-datetime catalog
+        from mmeq.analysis.aftershock import modified_omori_forecast
+        rng = np.random.default_rng(7)
+        ms = pd.Timestamp("2025-03-28 06:20:52")
+        hours = np.sort(rng.uniform(0.2, 30 * 24, 60))
+        after = pd.DataFrame({
+            "id": [f"as{i}" for i in range(60)],
+            "time_utc": [ms + pd.Timedelta(hours=h) for h in hours],
+            "latitude": 21.9, "longitude": 95.9, "depth": 10.0,
+            "mag": rng.uniform(3.0, 5.0, 60),
+        })
+        df = pd.concat([two_m77_catalog, after], ignore_index=True)
+        df["time_utc"] = pd.to_datetime(df["time_utc"])
+        _, params = modified_omori_forecast(df, min_mag=3.0)
+        assert params["mainshock_time"].startswith("2025-03-28")
+        assert params["mainshock_lat"] == pytest.approx(21.996)


### PR DESCRIPTION
Phase 1 of the integrity-audit fix sequence (findings **C1** and **M3** — both adversarially confirmed).

## What was wrong
- The catalog contains **two M7.7 events**. Every scenario consumer picked `nlargest(1,'mag')`/`idxmax()`, which tie-breaks to the first row: the **1988-11-06 Lancang-Gengma (Yunnan) earthquake**, not the 2025-03-28 Sagaing mainshock the README and paper describe. The 20%-weighted proximity component of every dam grade, the Monte-Carlo PGA study, the weight-sensitivity study, and the published aftershock forecast were all computed against an epicenter ~400 km away.
- The Omori fit used least-squares on log-binned counts (provably biased: p low by 0.2–0.4, K low severalfold; pinned at its silent p=0.5 clip on the real 2025 sequence) with c hardcoded to 0.1 h.

## The fix
- New shared `seismology.select_scenario_event`: max magnitude, **ties broken by recency**, optional `MMEQ_SCENARIO_EVENT_ID` pin. Wired into all three `dam_risk.py` sites and `aftershock.py`.
- `omori_params` rewritten as **Ogata (1983) MLE** on exact event times (closed-form profile K; L-BFGS-B over (ln c, p) with multi-start; warns at optimizer bounds).

## Number changes (verified locally, CI regenerates artifacts on merge)
| | old (published) | new |
|---|---|---|
| Dam grades C/H/M/L | 25/148/67/14 | **45/134/61/14** |
| Critical+High | 173 (68%) | **179 (70%)** |
| Omori (2025 M7.7) | K=4.53, c=0.1 h, p=0.932 *(1988 event!)* | **K=34.9, c=16.4 h, p=0.772** |
| MC dams P(PGA>0.2g)>50% | 34 | 34 (unchanged) |

Paper edits: grade table, stale '54%' → 70%, proximity term labeled '2025 M7.7', and the artifact-contradicted 'stays above 30% regardless of weights' robustness claim replaced with the actual distribution (median ~73%, 22/100 draws below 30%).

## Tests
- 6 new regression tests for scenario selection (tie-break, row-order independence, env pin, Omori integration).
- Synthetic Omori recovery test: simulated process with known (K,c,p), asserts |p̂−p| < 0.1.
- Full suite: **101 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)