### PR TITLE
fix(publish): daily-push site dispatch, live paper.pdf, popup XSS escaping, gitignore anchor

### DIFF
--- a/.github/workflows/daily_data_fetch.yml
+++ b/.github/workflows/daily_data_fetch.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   issues: write   # failure-notification step files/updates an issue
+  actions: write  # post-push dispatch of the Pages build (see below)
 
 # Never run two fetches at once (overlapping pushes would race); queue instead
 # of cancelling so a manual dispatch doesn't kill the scheduled run mid-push.
@@ -49,7 +50,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add quake_exports/
-          git diff --cached --quiet || git commit -m "feat: Update earthquake data"
+          git diff --cached --quiet || { git commit -m "feat: Update earthquake data"; echo "data_changed=1" >> "$GITHUB_ENV"; }
           # master may have moved while the export ran (e.g. a PR merge or the
           # report workflow's artifact commit) — rebase onto the new tip and
           # retry so a non-fast-forward doesn't fail the whole run. The push
@@ -62,6 +63,17 @@ jobs:
             git pull --rebase origin master || exit 1
           done
           [ "$pushed" = 1 ] || { echo "push failed after 3 attempts"; exit 1; }
+
+      - name: Trigger site rebuild
+        # Pushes made with GITHUB_TOKEN deliberately do not create workflow
+        # runs, so report_and_pages.yml's push trigger never fires for the
+        # daily bot commit — the dashboard silently served stale data for a
+        # month (2026-07-06 audit, finding M9). API-initiated dispatches DO
+        # create runs, so kick the build explicitly when data changed.
+        if: env.data_changed == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run report_and_pages.yml --ref master --repo "$GITHUB_REPOSITORY"
 
       - name: Notify on failure
         if: failure()

--- a/.github/workflows/report_and_pages.yml
+++ b/.github/workflows/report_and_pages.yml
@@ -9,7 +9,7 @@ on:
       - 'src/mmeq/**'
       - 'data/**'
       - 'generate_figures.py'
-      - 'tools/build_figure_data.py'
+      - 'tools/**'
       - 'paper/main.tex'
       - 'pyproject.toml'
       - 'docs/index.html'
@@ -86,11 +86,6 @@ jobs:
           mkdir -p docs/report
           mmeq report --output docs/report --reuse-risk
 
-      - name: Copy static map
-        run: |
-          cp -f docs/report/enhanced_earthquake_map.html docs/report/ 2>/dev/null || true
-          cp -f enhanced_earthquake_map.html docs/report/ 2>/dev/null || true
-
       - name: Regenerate paper figures
         run: |
           python generate_figures.py
@@ -102,6 +97,12 @@ jobs:
         with:
           root_file: main.tex
           working_directory: paper
+
+      - name: Publish paper PDF to the site
+        # docs/index.html links report/paper.pdf; without this copy the live
+        # site serves whatever stale PDF was last committed by hand (it served
+        # a 2-month-old paper — 2026-07-06 audit, finding C6).
+        run: cp -f paper/main.pdf docs/report/paper.pdf
 
       - name: Commit report, figures & paper artifacts
         if: github.ref == 'refs/heads/master'

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,10 @@ cluster_maps/
 dem_tiles/
 
 # Generated reports and data exports
-report/
+# Anchored: an unanchored 'report/' also matched docs/report/, silently
+# preventing NEW site artifacts (vendor/, plotly.min.js, paper.pdf) from ever
+# being committed (2026-07-06 audit).
+/report/
 dam_seismic_risk.csv
 
 # IDE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Publishing-seam fixes (2026-07-06 integrity audit, phase 3)
+
+- **Daily data pushes now trigger the site rebuild.** GITHUB_TOKEN pushes
+  deliberately create no workflow runs, so the dashboard silently served
+  stale data (all of June it showed May 31). The daily job now dispatches
+  `report_and_pages.yml` explicitly after a push that committed new data.
+- **The live paper PDF is now the built one**: CI copies `paper/main.pdf` to
+  `docs/report/paper.pdf`; the site had been serving a hand-committed copy
+  frozen on 2026-05-01, missing every subsequent correction.
+- **Stored-XSS closed on the public map**: dam CSV fields, OSM names and API
+  strings are HTML-escaped (incl. backticks — folium interpolates popups into
+  a jQuery template literal) before popup construction; regression test
+  asserts no raw payload reaches the saved HTML.
+- `.gitignore`'s unanchored `report/` (which also matched `docs/report/` and
+  silently blocked committing new site artifacts like `vendor/` and
+  `plotly.min.js`) anchored to `/report/`; dead "Copy static map" no-op step
+  removed; Pages triggers widened to `tools/**` (matches CLAUDE.md).
+
 ### Data-artifact repairs (2026-07-06 integrity audit, phase 2)
 
 - **Yearly JSON now merges instead of overwriting** (Python `save_merged_json`

--- a/src/mmeq/visualization/map.py
+++ b/src/mmeq/visualization/map.py
@@ -1,3 +1,4 @@
+import html
 import logging
 import os
 from typing import Optional
@@ -18,6 +19,18 @@ from mmeq.config import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _esc(value) -> str:
+    """HTML-escape a data-derived string before popup interpolation.
+
+    folium renders string popups verbatim inside a jQuery template literal in
+    the published page, so unescaped OSM names / dam CSV fields / API strings
+    are a stored-XSS vector on the public map (2026-07-06 audit, finding C7).
+    Backticks are escaped too — a literal one would terminate the template
+    literal and blank the map.
+    """
+    return html.escape(str(value)).replace("`", "&#96;")
 
 
 def _mag_color(mag: float) -> str:
@@ -88,7 +101,7 @@ def build_earthquake_map(
                 popup=(
                     f"<b>Magnitude:</b> {row['mag']}<br>"
                     f"<b>Depth:</b> {row['depth']} km<br>"
-                    f"<b>Time (MMT):</b> {row.get('time_mmt', 'N/A')}"
+                    f"<b>Time (MMT):</b> {_esc(row.get('time_mmt', 'N/A'))}"
                 ),
             ).add_to(target)
         marker_layer.add_to(quake_map)
@@ -117,17 +130,17 @@ def build_earthquake_map(
             capacity = row["capacity_mw"]
             height = row["height_m"]
             river = row["river"]
-            popup_html = f"<b>Dam:</b> {name}"
+            popup_html = f"<b>Dam:</b> {_esc(name)}"
             if status:
-                popup_html += f"<br><b>Status:</b> {status}"
+                popup_html += f"<br><b>Status:</b> {_esc(status)}"
             if func:
-                popup_html += f"<br><b>Function:</b> {func}"
+                popup_html += f"<br><b>Function:</b> {_esc(func)}"
             if capacity:
-                popup_html += f"<br><b>Capacity:</b> {capacity} MW"
+                popup_html += f"<br><b>Capacity:</b> {_esc(capacity)} MW"
             if height:
-                popup_html += f"<br><b>Height:</b> {height} m"
+                popup_html += f"<br><b>Height:</b> {_esc(height)} m"
             if river:
-                popup_html += f"<br><b>River:</b> {river}"
+                popup_html += f"<br><b>River:</b> {_esc(river)}"
             icon_color = "blue"
             if status == "Complete":
                 icon_color = "blue"
@@ -172,7 +185,7 @@ def build_earthquake_map(
                 fill=True,
                 fill_opacity=0.6,
                 weight=0,
-                popup=f"{row['category']}: {row['name']}" if row["name"] else row["category"],
+                popup=f"{_esc(row['category'])}: {_esc(row['name'])}" if row["name"] else _esc(row["category"]),
             ).add_to(osm_layer)
         osm_layer.add_to(quake_map)
         logger.info("Added %d OSM buildings to map", len(osm_df))

--- a/tests/test_map_escaping.py
+++ b/tests/test_map_escaping.py
@@ -1,0 +1,52 @@
+"""Stored-XSS regression: data-derived strings (dam CSV fields, OSM names,
+API strings) must be HTML-escaped before popup interpolation — folium renders
+string popups verbatim inside a jQuery template literal on the published map
+(2026-07-06 audit, finding C7)."""
+import json
+
+import pandas as pd
+
+from mmeq.visualization.map import _esc, build_earthquake_map
+
+PAYLOAD = "<img src=x onerror=alert(1)>"
+
+
+def test_esc_neutralizes_html_and_backticks():
+    out = _esc(f"Evil `{PAYLOAD}` dam")
+    assert "<" not in out and ">" not in out and "`" not in out
+    assert "&lt;img" in out and "&#96;" in out
+
+
+def test_map_html_contains_no_unescaped_payload(tmp_path):
+    dams = {
+        "type": "FeatureCollection",
+        "features": [{
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [96.0, 21.5]},
+            "properties": {
+                "name": PAYLOAD,
+                "status": f"Complete{PAYLOAD}",
+                "function": "Irrigation",
+                "river": f"`backtick`{PAYLOAD}",
+            },
+        }],
+    }
+    dams_path = tmp_path / "dams.geojson"
+    dams_path.write_text(json.dumps(dams), encoding="utf-8")
+
+    df = pd.DataFrame({
+        "time_utc": ["2025-03-28 06:20:52"],
+        "time_mmt": [f"2025-03-28 12:50:52{PAYLOAD}"],
+        "latitude": [21.996],
+        "longitude": [95.926],
+        "depth": [10.0],
+        "mag": [7.7],
+    })
+    out = str(tmp_path / "map.html")
+    build_earthquake_map(
+        df, output_path=out, dams_path=str(dams_path),
+        show_heatmap=False, cluster_markers=False,
+    )
+    html_text = open(out, encoding="utf-8").read()
+    assert PAYLOAD not in html_text, "raw payload reached the published HTML"
+    assert "&lt;img src=x" in html_text, "escaped payload should be present"


### PR DESCRIPTION
Phase 3 of the integrity-audit fix sequence (findings **M9**, **C6**, **C7** + two build minors — all adversarially confirmed).

- **M9 — dashboard silently stale:** `GITHUB_TOKEN` pushes never create workflow runs, so the daily data commit never triggered the Pages build (the site served May-31 data all June). The daily job now records `data_changed` at commit time and, after a successful push, dispatches `report_and_pages.yml` via `gh workflow run` (API dispatches DO create runs; `actions: write` added).
- **C6 — 2-month-old paper on the live site:** CI builds `paper/main.pdf` but the site links `report/paper.pdf`, which was a hand-committed copy from 2026-05-01. The build now copies the fresh PDF into `docs/report/`.
- **C7 — stored XSS on the public map:** dam CSV fields, world-editable OSM names, and API strings were interpolated raw into folium popups (which land inside a jQuery template literal). New `_esc()` escapes HTML *and backticks*; regression test builds a map with a live payload and asserts only the escaped form reaches the saved HTML.
- **Minors:** `.gitignore` `report/` anchored to `/report/` (the unanchored form also matched `docs/report/`, silently blocking new site artifacts like `vendor/` and `plotly.min.js` from ever being committed — the repo tree references files git doesn't have); dead 'Copy static map' no-op step deleted; Pages `paths` widened to `tools/**` to match CLAUDE.md.

Tests: 105 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)