### PR TITLE
fix(security): escape $ in map popups — close ${...} template-literal XSS bypass

### DIFF
--- a/src/mmeq/visualization/map.py
+++ b/src/mmeq/visualization/map.py
@@ -28,9 +28,13 @@ def _esc(value) -> str:
     the published page, so unescaped OSM names / dam CSV fields / API strings
     are a stored-XSS vector on the public map (2026-07-06 audit, finding C7).
     Backticks are escaped too — a literal one would terminate the template
-    literal and blank the map.
+    literal and blank the map — and so is "$": inside a template literal
+    ${expr} is EVALUATED as JavaScript, so an unescaped dollar sign is its own
+    execution vector (Kilo review of PR #36). HTML entities are not decoded by
+    the JS parser, so "&#36;" can never form "${" in the literal, while jQuery
+    renders it back as a visible "$".
     """
-    return html.escape(str(value)).replace("`", "&#96;")
+    return html.escape(str(value)).replace("`", "&#96;").replace("$", "&#36;")
 
 
 def _mag_color(mag: float) -> str:

--- a/tests/test_map_escaping.py
+++ b/tests/test_map_escaping.py
@@ -9,12 +9,21 @@ import pandas as pd
 from mmeq.visualization.map import _esc, build_earthquake_map
 
 PAYLOAD = "<img src=x onerror=alert(1)>"
+TPL_PAYLOAD = "${alert(1)}"
 
 
 def test_esc_neutralizes_html_and_backticks():
     out = _esc(f"Evil `{PAYLOAD}` dam")
     assert "<" not in out and ">" not in out and "`" not in out
     assert "&lt;img" in out and "&#96;" in out
+
+
+def test_esc_neutralizes_template_interpolation():
+    # popups land inside a backtick template literal, where ${expr} is
+    # EVALUATED — escaping tags and backticks alone is not enough.
+    out = _esc(f"Dam {TPL_PAYLOAD} river")
+    assert "${" not in out
+    assert "&#36;" in out
 
 
 def test_map_html_contains_no_unescaped_payload(tmp_path):
@@ -27,7 +36,7 @@ def test_map_html_contains_no_unescaped_payload(tmp_path):
                 "name": PAYLOAD,
                 "status": f"Complete{PAYLOAD}",
                 "function": "Irrigation",
-                "river": f"`backtick`{PAYLOAD}",
+                "river": f"`backtick`{PAYLOAD}{TPL_PAYLOAD}",
             },
         }],
     }
@@ -49,4 +58,5 @@ def test_map_html_contains_no_unescaped_payload(tmp_path):
     )
     html_text = open(out, encoding="utf-8").read()
     assert PAYLOAD not in html_text, "raw payload reached the published HTML"
+    assert TPL_PAYLOAD not in html_text, "raw ${...} interpolation reached the published HTML"
     assert "&lt;img src=x" in html_text, "escaped payload should be present"


### PR DESCRIPTION
Follow-up to PR #36, addressing Kilo's CRITICAL review comment.

folium places each popup's HTML **verbatim inside a JavaScript backtick template literal** (`var html_xxx = $(`…`)[0]`). PR #36 escaped HTML tags and backticks, but inside a template literal **`${expr}` is evaluated as JavaScript** — so an unescaped `$` was still an execution vector (e.g. a dam `river` field or OSM name containing `${alert(1)}`).

`_esc` now also maps `$` → `&#36;`: HTML entities are never decoded by the JS parser, so `&#36;{` can never form `${` in the literal, while jQuery renders it back to a visible `$` in the popup. The regression test gains a `${alert(1)}` payload (in `river`) and asserts the raw `${` never reaches the saved HTML.

Tests: 3 passed (map escaping), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)