### PR TITLE
docs(paper): fig2 Aki-MLE line, honest fragility text, consistency sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,23 @@
   it); dead `aftershock_probability_grid` (hardcoded "30 days ago", uncalled)
   removed.
 
+### Paper & docs consistency sweep (2026-07-06 integrity audit, phase 5)
+
+- **Figure 2 G-R line now uses the Aki (1965) MLE b-value** the text quotes
+  (b≈0.71), not a least-squares fit on correlated cumulative counts that
+  read b=0.90 and contradicted the prose at the same cutoff (finding M4).
+- **Fragility claim made honest**: "5 dams reach Moderate" (which matched no
+  shipped artifact) replaced with snapshot-aware wording pointing at
+  `report/dam_fragility.json`, plus an explicit statement that the dam
+  database has no construction-type field so all dams are treated as earthfill
+  and the log-normal medians are assumed (findings M8 + dam-type minor).
+- **Mc convergence** prose and figure caption reconciled (they said 4.0 vs
+  4.5); event counts corrected to 9,420 across paper/README/docs; README
+  figure count 13→14 and the fig6 row fixed (temporal evolution, not a dam
+  map); the untraceable ShakeMap-grid check relabeled as an offline one-off
+  with the ratio arithmetic fixed (0.78, not 0.79); dashboard per-year and
+  total counts refreshed.
+
 ### Hazard-model corrections (2026-07-06 integrity audit, phase 4 — spec 006)
 
 - **Scenario "rupture distance" now uses the actual 2025 rupture geometry**

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Daily Fetch](https://github.com/akzedevops/mmeqopendata/actions/workflows/daily_data_fetch.yml/badge.svg)](https://github.com/akzedevops/mmeqopendata/actions/workflows/daily_data_fetch.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/Python-3.9+-green.svg)](https://python.org)
-[![Events](https://img.shields.io/badge/Earthquakes-9%2C242-orange.svg)](https://akzedevops.github.io/mmeqopendata/)
+[![Events](https://img.shields.io/badge/Earthquakes-9%2C420-orange.svg)](https://akzedevops.github.io/mmeqopendata/)
 
 A hobby project for collecting, analyzing, and visualizing earthquake data in Myanmar. Built on the [Myanmar Earthquake API](https://mmeq.akze.net), covering records from 1950 to present.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A hobby project for collecting, analyzing, and visualizing earthquake data in My
 
 **Live dashboard:** [https://akzedevops.github.io/mmeqopendata/](https://akzedevops.github.io/mmeqopendata/)
 
-**Write-up:** [`paper/main.pdf`](paper/main.pdf) — a casual hobby write-up on Myanmar dam seismic risk with 13 figures and open data.
+**Write-up:** [`paper/main.pdf`](paper/main.pdf) — a casual hobby write-up on Myanmar dam seismic risk with 14 figures and open data.
 
 ## What It Does
 
@@ -143,7 +143,9 @@ I validated the GMPE against the actual Naypyidaw ShakeMap recording — predict
 
 ## How the Seismology Works
 
-The catalog has 9,390 events. Most are small (mean M 3.2), but there are 6 events ≥ M7.0 and 358 ≥ M5.0.
+The catalog has 9,420 events. Most are small (mean M 3.2), but there are 6 events ≥ M7.0 and 357 ≥ M5.0.
+
+**Known catalog gaps:** the upstream source has no events for the ~18 months from 2013-09 through 2015-02 (all of 2014 is empty), so any rate/temporal analysis over that window is biased low. The catalog is a multi-network union deduplicated by event id only, so a handful of events reported by two networks under different id schemes survive as near-duplicates; the effect on aggregate statistics is negligible (~3 of 9,420) but present.
 
 **b-value and completeness:** On the full catalog the Gutenberg-Richter b-value at Mc = 4.0 is 0.71, but the raw value (auto-Mc ≈ 2.4) drops to 0.35 — an artifact of the 2025 aftershock sequence flooding the small-magnitude bins. After Gardner-Knopoff (1974) declustering — magnitude-dependent space-time windows, e.g. ~86 km / ~967 days for the M7.7 — the catalog yields Mc ≈ 4.7 and b ≈ 1.05, typical for a tectonic region. The probabilistic hazard below uses these declustered rates.
 
@@ -175,11 +177,11 @@ For each building, PGA is estimated using the same ASK08 GMPE with rupture dista
 
 Uses site-specific Vs30 from the USGS ShakeMap grid (mean 320 m/s) — soft soils in the Irrawaddy basin amplify shaking significantly compared to reference rock.
 
-Validated against the USGS ShakeMap grid — Naypyidaw prediction is 0.43g vs USGS 0.55g (ratio 0.79). Near-fault underprediction is expected because this was a supershear rupture.
+As a one-off offline check against the USGS ShakeMap grid (not tracked in this repo, unlike the station-list comparison, which regenerates in CI), the Naypyidaw prediction was ~0.43g vs USGS ~0.55g (ratio ~0.78). Near-fault underprediction is expected because this was a supershear rupture.
 
 ## Figures
 
-13 figures in [`paper/figures/`](paper/figures/) (300 DPI, PDF + PNG):
+14 figures in [`paper/figures/`](paper/figures/) (300 DPI, PDF + PNG):
 
 | Figure | Description |
 |---|---|
@@ -188,7 +190,7 @@ Validated against the USGS ShakeMap grid — Naypyidaw prediction is 0.43g vs US
 | fig3 | Depth histogram + magnitude vs depth |
 | fig4 | Dam risk map (color-coded by grade) |
 | fig5 | ASK08 PGA attenuation curves with recorded data |
-| fig6 | Dam risk map with all 254 dams |
+| fig6 | Annual earthquake counts (temporal evolution) |
 | fig7 | Risk score distribution + grade counts + Monte Carlo sensitivity |
 | fig8 | Dam status and function breakdowns |
 | fig9 | Vs30 site classification map |

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,7 +56,7 @@
 
     <div class="container">
         <div class="stats">
-            <div class="stat-card"><div class="number">9,390</div><div class="label">Earthquake Events</div></div>
+            <div class="stat-card"><div class="number">9,420</div><div class="label">Earthquake Events</div></div>
             <div class="stat-card"><div class="number">M7.7</div><div class="label">2025 Mandalay Earthquake</div></div>
             <div class="stat-card"><div class="number">173</div><div class="label">Dams Critical/High Risk</div></div>
             <div class="stat-card"><div class="number">34,224</div><div class="label">Buildings Assessed</div></div>
@@ -68,7 +68,7 @@
             <div class="card">
                 <div class="card-header bg-map">Earthquake Map</div>
                 <div class="card-body">
-                    <p>9,390 earthquakes with heatmap, fault lines, and 254 dams including the 2025 M7.7 rupture trace.</p>
+                    <p>9,420 earthquakes with heatmap, fault lines, and 254 dams including the 2025 M7.7 rupture trace.</p>
                     <a href="report/enhanced_earthquake_map.html" class="btn bg-map" target="_blank">Open Map</a>
                 </div>
             </div>
@@ -216,7 +216,7 @@
     <script>
     const REPO = 'https://raw.githubusercontent.com/akzedevops/mmeqopendata/master/quake_exports';
     const YEARS = {
-        2026:350,2025:2554,2024:621,2023:722,2022:1897,2021:467,2020:388,
+        2026:613,2025:2469,2024:621,2023:722,2022:1897,2021:467,2020:388,
         2019:89,2018:91,2017:87,2016:36,2015:17,2013:11,2012:71,2011:71,
         2010:28,2009:37,2008:122,2007:83,2006:61,2005:75,2004:108,2003:104,
         2002:36,2001:44,2000:40,1999:32,1998:41,1997:45,1996:70,1995:72,

--- a/generate_figures.py
+++ b/generate_figures.py
@@ -128,16 +128,21 @@ mask_cum = cumulative_counts > 0
 ax1_2.plot(centers[mask_cum], cumulative_counts[mask_cum], "k.", markersize=2, alpha=0.5)
 
 mc_corrected = 4.0
+# Draw the G-R line from the SAME Aki (1965) MLE b-value the paper text quotes.
+# The previous least-squares fit on cumulative counts gave b=0.90, contradicting
+# the text's b=0.71 at the identical cutoff (2026-07-06 audit, finding M4);
+# cumulative counts are strongly correlated, so LS on them is not the estimator.
+from mmeq.analysis.seismology import b_value as _aki_b
+b_val, _a_cat, _mc = _aki_b(pd.Series(mags), min_mag=mc_corrected)
 mask = (centers >= mc_corrected) & (counts > 0)
 if mask.sum() > 2:
-    log_N_cum = np.log10(np.maximum(cumulative_counts[mask], 1))
-    coeffs = np.polyfit(centers[mask], log_N_cum, 1)
-    b_val = -coeffs[0]
-    a_val = coeffs[1]
+    # anchor the line to the observed cumulative count at Mc
+    n_at_mc = float(cumulative_counts[np.argmax(centers >= mc_corrected)])
+    a_val = np.log10(max(n_at_mc, 1)) + b_val * mc_corrected
     x_fit = np.linspace(mc_corrected, mags.max(), 100)
     y_fit = 10 ** (a_val - b_val * x_fit)
     ax1_2.plot(x_fit, y_fit, "r-", linewidth=2,
-               label=f"GR fit (b={b_val:.2f})")
+               label=f"GR fit (Aki MLE, b={b_val:.2f})")
     ax1_2.set_yscale("log")
     ax1_2.set_ylabel("Cumulative frequency (N)", color="red")
 

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -92,7 +92,7 @@ Buildings (34,224) & OpenStreetMap (Overpass API) & ODbL \\
 % ============================================================
 
 The catalog has 9,420 events.
-Most are small (mean M\,3.2), but there are 6 events $\geq$\,M7.0 and 358 $\geq$\,M5.0.
+Most are small (mean M\,3.2), but there are 6 events $\geq$\,M7.0 and 357 $\geq$\,M5.0.
 About 75\% are shallow ($<$30\,km), which makes sense---the Sagaing Fault is a crustal structure.
 
 \begin{figure}[htbp]

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -386,6 +386,7 @@ Near-fault sites are systematically low because this was a supershear rupture, w
 
     \item \textbf{Catalog completeness is sneaky.}
     The raw b-value of 0.35 looked alarming but was just an artifact of mixing 1970s data (only M4.5+ detected) with 2020s data (M2+ detected) and the 2025 aftershock burst.
+    A second caveat: the catalog pools magnitude types (\raise.17ex\hbox{$\scriptstyle\sim$}74\% $m_l$, \raise.17ex\hbox{$\scriptstyle\sim$}22\% $m_b$, \raise.17ex\hbox{$\scriptstyle\sim$}2\% $M_w$) without converting to a common moment-magnitude scale, so the FMD slope carries some inter-scale bias on top of the completeness effect.
     Always check stability before trusting a b-value.
 
     \item \textbf{Over half of Myanmar's dams are in high-hazard zones.}

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -56,7 +56,7 @@ I wanted to know: which dams are most at risk, and can we quantify it with open 
 \subsection{What This Project Does}
 
 \begin{itemize}
-    \item Pulls 9,390 earthquake records (1970--2026) from the \href{https://mmeq.akze.net}{Myanmar Earthquake API}
+    \item Pulls 9,420 earthquake records (1970--2026) from the \href{https://mmeq.akze.net}{Myanmar Earthquake API}
     \item Scores all 254 dams for seismic risk using a proper ground-motion model
     \item Runs probabilistic hazard curves, Coulomb stress transfer, fragility analysis
     \item Validates predictions against actual recorded ground motions
@@ -91,7 +91,7 @@ Buildings (34,224) & OpenStreetMap (Overpass API) & ODbL \\
 \section{The Earthquake Catalog}
 % ============================================================
 
-The catalog has 9,390 events.
+The catalog has 9,420 events.
 Most are small (mean M\,3.2), but there are 6 events $\geq$\,M7.0 and 358 $\geq$\,M5.0.
 About 75\% are shallow ($<$30\,km), which makes sense---the Sagaing Fault is a crustal structure.
 
@@ -108,14 +108,14 @@ The Gutenberg-Richter law says $\log_{10} N = a - bM$.
 The tricky part is that the catalog is incomplete at small magnitudes---the 1970s network couldn't detect M2 events, but the modern network can.
 If you naively fit all the data, you get $b = 0.35$, which is way too low (global average is $\sim$1.0). After Gardner-Knopoff (1974) declustering --- magnitude-dependent space-time windows, e.g.\ $\sim$86\,km and $\sim$967 days for the M7.7 mainshock --- $M_c \approx 4.7$ and $b \approx 1.05$, typical for a tectonic region; these are the rates used for the probabilistic hazard below.
 
-A stability analysis (Figure~\ref{fig:fmd}b) shows the b-value only converges at $M_c \geq 4.0$.
+A stability analysis (Figure~\ref{fig:fmd}b) shows the b-value stabilizes around $M_c \approx 4.0$--$4.5$; the headline fit uses $M_c = 4.0$.
 Using that cutoff: $b = 0.71 \pm 0.02$ with 2,473 events.
 That's below the global average but reasonable for a region with frequent large earthquakes.
 
 \begin{figure}[htbp]
     \centering
     \includegraphics[width=\textwidth]{figures/fig2_fmd.png}
-    \caption{(a) Frequency-magnitude distribution with G-R fit above $M_c = 4.0$. (b) b-value stability---it only converges around $M_c = 4.5$, confirming the catalog is incomplete below M4.}
+    \caption{(a) Frequency-magnitude distribution with G-R fit above $M_c = 4.0$. (b) b-value stability---it stabilizes around $M_c \approx 4.0$--$4.5$, confirming the catalog is incomplete below M4. The G-R line in (a) uses the Aki (1965) MLE b-value at $M_c = 4.0$, the same estimate quoted in the text.}
     \label{fig:fmd}
 \end{figure}
 
@@ -306,8 +306,7 @@ Using that, at the standard $\pm$0.01\,MPa (0.1\,bar) threshold, 16 dams (6\%) a
 
 \subsection{Dam Fragility Curves}
 
-Using HAZUS-style log-normal fragility functions for earthfill, concrete, and rockfill dams, most dams fall in the ``None'' or ``Slight'' damage state for the deterministic M7.7 scenario.
-5 dams reach ``Moderate'' damage probability.
+Using HAZUS-informed log-normal fragility functions, most dams fall in the ``None'' or ``Slight'' damage state for the deterministic M7.7 scenario; only a handful reach ``Moderate'' damage probability (the exact count tracks the current catalog snapshot and is written to \texttt{report/dam\_fragility.json}). The dam database carries no construction-type field, so every dam is treated as earthfill/embankment; the concrete and rockfill parameter sets exist in the code but are not exercised, and the log-normal medians are assumed values informed by---not taken verbatim from---the cited studies.
 
 \begin{figure}[htbp]
     \centering
@@ -364,8 +363,7 @@ Among these: 2,166 schools and 901 hospitals had PGA above 0.1$g$.
 
 Using site-specific Vs30 from the USGS ShakeMap grid (mean 320\,m/s, range 180--900\,m/s) instead of a flat 760\,m/s reference rock makes a big difference---soft soils in the Irrawaddy basin amplify shaking significantly.
 
-I validated against the USGS ShakeMap grid.
-At Naypyidaw, our prediction is 0.43$g$ vs USGS 0.55$g$ (ratio 0.79)---reasonable for a pure GMPE without the 1,244 DYFI felt reports that USGS incorporates.
+As a one-off offline check against the USGS ShakeMap \emph{grid} (not tracked in this repo, unlike the station comparison in Table~\ref{tab:validation}, which regenerates from \texttt{data/shakemap/stationlist.json}), the Naypyidaw prediction was $\approx$0.43$g$ vs USGS $\approx$0.55$g$ (ratio $\approx$0.78)---reasonable for a pure GMPE without the 1,244 DYFI felt reports that USGS incorporates.
 
 Applying HAZUS casualty ratios to the 34,224 buildings (assuming 50 indoor occupants each) gives a rough loss estimate: about 970 injuries, 38 hospitalizations, and 346 buildings with complete structural damage.
 Near-fault sites are systematically low because this was a supershear rupture, which amplifies ground motions beyond what standard GMPEs predict.

--- a/src/mmeq/analysis/seismology.py
+++ b/src/mmeq/analysis/seismology.py
@@ -14,6 +14,12 @@ def b_value(
     """
     Calculate b-value using the maximum likelihood method (Aki, 1965).
     Returns (b_value, a_value, min_mag_used).
+
+    Caveat: the input magnitudes are taken as-is. The catalog pools magnitude
+    types (~74% ml, ~22% mb, ~2% Mw) without converting to a common Mw scale,
+    so the FMD slope carries some inter-scale bias (mb saturates near 6;
+    ml-Mw offsets of 0.2-0.5 are typical). Documented, not corrected — the
+    paper states this alongside the completeness caveat (2026-07-06 audit).
     """
     magnitudes = magnitudes.dropna()
     if min_mag is None:


### PR DESCRIPTION
Phase 5 — the paper/README text sweep (findings **M4**, **M8**, and the documentation minors). Stacked after phase 4 (rupture/PSHA), now rebased onto master.

- **M4 — Figure 2 G-R fit contradicted the text.** `generate_figures.py` drew the panel-(a) line via least-squares on cumulative counts, giving b=0.90 in the legend while the prose (and the Aki-1965 MLE) says b=0.71 at the same Mc. The line now uses the **Aki MLE b** the text quotes, anchored at Mc.
- **M8 — fragility claim matched no artifact.** "5 dams reach Moderate" (was 6 at paper date, 9 later, 4 now) replaced with snapshot-aware wording pointing at `report/dam_fragility.json`, plus the honest disclosure that the dam database has no construction-type field (so all dams are treated as earthfill; the concrete/rockfill branches are dead) and the log-normal medians are assumed values.
- **Doc minors:** Mc-convergence prose/caption reconciled (said 4.0 vs 4.5); event counts → 9,420 across paper/README/docs; README 13→14 figures and the fig6 row (temporal evolution, not a dam map); the untraceable ShakeMap-*grid* check relabeled an offline one-off with the ratio arithmetic fixed (0.78); dashboard stat/per-year counts refreshed; a **known-gaps** note added (empty 2014, id-only multi-network dedup).

Figures are regenerated by CI on merge. Tests + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)