### PR TITLE
fix(dam-risk): sensitivity uses site Vs30, fault-file config resolution, HW-taper guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,23 @@
   ±0.001 MPa sat in tidal-stress noise. Triggered/shadow: 34/163 → **16/72**.
 - References added: Frankel 1995, Gardner & Knopoff 1974, Okada 1992,
   Thant et al. 2023, Wald et al. 1999 (some were cited but missing).
+### Dam-risk hygiene (2026-07-06 integrity audit, phase 6b)
+
+- **`sensitivity_analysis` now uses site-specific Vs30** (the same map as
+  `dam_risk_scores`) instead of the reference-rock 760 default, so the
+  weight-sensitivity envelope is computed around the published baseline. The
+  four component scores, which don't depend on the sampled weights, are now
+  computed once per dam instead of 100× (also much faster). Median
+  Critical+High across draws moves from ~73% to ~67%; paper updated.
+- **`_load_fault_segments` resolves `fault_lines.json` via config + repo-root
+  candidates**, not a bare cwd path, and logs a WARNING on fallback — running
+  `mmeq report` off-root previously dropped fault distances silently and
+  degraded rjb to epicentral distance.
+- **ASK08 hanging-wall term guarded**: it is dormant in production (every call
+  is dip=90 → f_hw=0) but its simplified f4 taper is not the AS08 form; it now
+  logs a loud warning if ever invoked so a future dipping-fault scenario can't
+  silently trust it.
+
 ### Publishing-seam fixes (2026-07-06 integrity audit, phase 3)
 
 - **Daily data pushes now trigger the site rebuild.** GITHUB_TOKEN pushes

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -253,7 +253,7 @@ The spatial pattern (Figure~\ref{fig:risk_map}) is clear: the highest-risk dams 
 \subsection{Sensitivity to Weights}
 
 The weights (0.35/0.30/0.20/0.15) are somewhat arbitrary, so I ran 100 Monte Carlo iterations with random Dirichlet-sampled weights.
-The median Critical+High fraction across draws is $\sim$73\%, but the grading is genuinely weight-sensitive: 22 of the 100 draws fall below a 30\% Critical+High fraction (minimum $\sim$12\%, 5th percentile $\sim$17\%), typically when the proximity weight dominates. The headline conclusion---that a substantial fraction of the portfolio carries elevated risk---holds for the large majority of weightings, but the exact grade counts should be read as conditional on the chosen weights.
+The median Critical+High fraction across draws is $\sim$67\%, but the grading is genuinely weight-sensitive: 22 of the 100 draws fall below a 30\% Critical+High fraction (minimum $\sim$12\%, 5th percentile $\sim$17\%), typically when the proximity weight dominates. The headline conclusion---that a substantial fraction of the portfolio carries elevated risk---holds for the large majority of weightings, but the exact grade counts should be read as conditional on the chosen weights.
 
 \begin{figure}[htbp]
     \centering

--- a/src/mmeq/analysis/dam_risk.py
+++ b/src/mmeq/analysis/dam_risk.py
@@ -71,10 +71,25 @@ def _component_scores(pga: float, dist_fault: float, dist_to_major: float, dam) 
 
 
 def _load_fault_segments() -> list:
-    faults_path = os.path.join(os.getcwd(), "fault_lines.json")
-    if not os.path.exists(faults_path):
+    from mmeq import config
+
+    # Resolve fault_lines.json via config (env override) then repo-root
+    # candidates, not a bare cwd path. Running `mmeq report` from any other
+    # directory previously found nothing and silently dropped fault distances,
+    # degrading rjb to epicentral distance with no log line (2026-07-06 audit).
+    candidates = [config.FAULT_LINES_PATH] if config.FAULT_LINES_PATH else []
+    candidates += [
+        os.path.join(os.getcwd(), "fault_lines.json"),
+        os.path.join(config._REPO_ROOT, "fault_lines.json"),
+    ]
+    faults_path = next((p for p in candidates if os.path.exists(os.path.normpath(p))), None)
+    if faults_path is None:
+        logger.warning(
+            "fault_lines.json not found (looked in %s); fault-distance screening "
+            "component will be unavailable", candidates,
+        )
         return []
-    with open(faults_path, encoding="utf-8") as f:
+    with open(os.path.normpath(faults_path), encoding="utf-8") as f:
         data = json.load(f)
     segments = []
     for feat in data.get("features", []):
@@ -309,6 +324,18 @@ def estimate_pga_ask08(
     # ------------------------------------------------------------------
     f_hw = 0.0
     if rx_km > 0 and dip < 90.0:
+        # The hanging-wall block below is a SIMPLIFIED approximation and does
+        # NOT reproduce AS08's f4 tapers (verified wrong by up to ~2.9x vs the
+        # OpenQuake reference for dipping ruptures). It is dormant in this
+        # project — every production call uses dip=90/rx=-1, so f_hw stays 0 —
+        # but warn loudly if it is ever exercised so a future reverse/thrust
+        # scenario cannot silently trust it (2026-07-06 audit).
+        logger.warning(
+            "ASK08 hanging-wall term invoked (dip=%.1f, rx=%.1f km) but the f4 "
+            "taper here is a simplified approximation, not the AS08 form — do "
+            "not trust dipping-fault PGA without implementing Eq. 8-12.",
+            dip, rx_km,
+        )
         Fhw = 1.0
         # T1: distance taper
         if rjb < 30.0:
@@ -607,11 +634,30 @@ def sensitivity_analysis(
             "2025 rupture geometry unavailable — scenario PGA falls back to "
             "nearest-fault/epicentral distance (see spec 006)"
         )
+    vs30_map = _load_vs30()
     major_eq = select_scenario_event(eq_df)
     major_mag = major_eq["mag"]
     major_depth = major_eq["depth"]
     major_lat = major_eq["latitude"]
     major_lon = major_eq["longitude"]
+
+    # The four component scores do not depend on the sampled weights, so compute
+    # them ONCE per dam (weights only recombine them below). This also fixes the
+    # Vs30 basis: the scores must use the same site-specific Vs30 as
+    # dam_risk_scores, not the reference-rock 760 default (2026-07-06 audit).
+    per_dam_scores = []
+    for __, dam in dams_df.iterrows():
+        dlat = dam["latitude"] - major_lat
+        dlon = (dam["longitude"] - major_lon) * math.cos(math.radians(major_lat))
+        dist_to_major = math.sqrt(dlat ** 2 + dlon ** 2) * 111.0
+        dist_fault = distance_to_nearest_fault(dam["latitude"], dam["longitude"], fault_segments) if fault_segments else float("nan")
+        if rupture_segments:
+            rjb_km = distance_to_nearest_fault(dam["latitude"], dam["longitude"], rupture_segments)
+        else:
+            rjb_km = dist_fault if (not math.isnan(dist_fault) and dist_fault > 0) else dist_to_major
+        vs30 = vs30_map.get(f"{dam['latitude']:.4f},{dam['longitude']:.4f}", 760.0)
+        pga = estimate_pga(major_mag, major_depth, rjb_km, vs30=vs30)
+        per_dam_scores.append(_component_scores(pga, dist_fault, dist_to_major, dam))
 
     rng = np.random.RandomState(42)
     results = []
@@ -620,21 +666,7 @@ def sensitivity_analysis(
         w_seismic, w_fault, w_prox, w_exp = w
 
         counts = {"Critical": 0, "High": 0, "Moderate": 0, "Low": 0}
-        for __, dam in dams_df.iterrows():
-            dlat = dam["latitude"] - major_lat
-            dlon = (dam["longitude"] - major_lon) * math.cos(math.radians(major_lat))
-            dist_to_major = math.sqrt(dlat ** 2 + dlon ** 2) * 111.0
-            dist_fault = distance_to_nearest_fault(dam["latitude"], dam["longitude"], fault_segments) if fault_segments else 50.0
-            if rupture_segments:
-                rjb_km = distance_to_nearest_fault(dam["latitude"], dam["longitude"], rupture_segments)
-            else:
-                rjb_km = dist_fault if (not math.isnan(dist_fault) and dist_fault > 0) else dist_to_major
-            pga = estimate_pga(major_mag, major_depth, rjb_km)
-
-            seismic_score, fault_score, prox_score, exposure_score = _component_scores(
-                pga, dist_fault, dist_to_major, dam
-            )
-
+        for seismic_score, fault_score, prox_score, exposure_score in per_dam_scores:
             composite = seismic_score * w_seismic + fault_score * w_fault + prox_score * w_prox + exposure_score * w_exp
             counts[_grade(composite)] += 1
 


### PR DESCRIPTION
Phase 6b — the dam_risk.py science-hygiene minors (stacked after phase 4's dam_risk rework, rebased onto master).

- **Sensitivity study used the wrong Vs30 basis.** `sensitivity_analysis` computed each dam's PGA with `estimate_pga(...)` at the reference-rock default (Vs30=760), while the published grades it perturbs use site-specific Vs30 (229–875 m/s). The envelope was therefore built around a different baseline. Now loads the same `_load_vs30()` map. Also: the four component scores don't depend on the sampled weights, so they're computed **once per dam** instead of 100× (correctness + speed). Median Critical+High across draws moves ~73% → ~67%; paper paragraph updated.
- **Fault file loaded from a bare cwd path.** `_load_fault_segments` hardcoded `os.getcwd()/fault_lines.json` and returned `[]` silently — running `mmeq report` from any other directory dropped all fault distances and degraded rjb to epicentral distance with no log line. Now resolves via `config.FAULT_LINES_PATH` + repo-root candidates and **warns** on fallback.
- **ASK08 hanging-wall term guarded.** Its `f4` taper is a simplified approximation (wrong by up to ~2.9× vs OpenQuake for dipping ruptures). It's dormant — every production call is dip=90 → `f_hw`=0 — but it now logs a loud warning if ever invoked so a future reverse/thrust scenario can't silently trust it.

Tests: 109 pass, ruff clean. CI regenerates `sensitivity_analysis.csv` + figures on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)