### PR TITLE
docs: fix missing blank line before phase-6b changelog header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
   ±0.001 MPa sat in tidal-stress noise. Triggered/shadow: 34/163 → **16/72**.
 - References added: Frankel 1995, Gardner & Knopoff 1974, Okada 1992,
   Thant et al. 2023, Wald et al. 1999 (some were cited but missing).
+
 ### Dam-risk hygiene (2026-07-06 integrity audit, phase 6b)
 
 - **`sensitivity_analysis` now uses site-specific Vs30** (the same map as


### PR DESCRIPTION
Cosmetic: the phase-4 and phase-6b CHANGELOG entries merged adjacent (independent PRs), leaving the `### Dam-risk hygiene` header without its preceding blank line, so it rendered as list text. One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)