### PR TITLE
docs(spec): mark spec 006 Done + add to index

### DIFF
--- a/specs/006-hazard-model-corrections.md
+++ b/specs/006-hazard-model-corrections.md
@@ -1,7 +1,7 @@
 ---
 spec: 006
 title: Hazard-model corrections — scenario rupture distance, PSHA source model, Coulomb kernel
-status: In progress    # Draft | Approved | In progress | Done
+status: Done           # Draft | Approved | In progress | Done
 author: Claude (2026-07-06 integrity audit) + Aung Khant Zaw
 created: 2026-07-06
 ---
@@ -90,16 +90,16 @@ numbers, paper sections 'Results', 'Probabilistic Hazard', 'Coulomb'.
 
 ## Acceptance criteria
 
-- [ ] Parity unit test: for a single patch, ΔCFS(−r) == ΔCFS(+r) to machine
+- [x] Parity unit test: for a single patch, ΔCFS(−r) == ΔCFS(+r) to machine
       precision; a strike-parallel receiver field shows 4 alternating-sign
       lobes around one patch.
-- [ ] Regenerated Coulomb dam counts published with the ±0.01 MPa threshold;
+- [x] Regenerated Coulomb dam counts published with the ±0.01 MPa threshold;
       README/paper/fig11 updated together.
-- [ ] `dam_risk_scores.csv` carries `dist_to_rupture_km`; Ta Nai Hka's
+- [x] `dam_risk_scores.csv` carries `dist_to_rupture_km`; Ta Nai Hka's
       scenario PGA drops below 0.05 g and its published grade is recomputed
       accordingly; no dam >300 km from the rupture keeps a near-fault
       scenario PGA.
-- [ ] Smoothed-seismicity PSHA conserves the total regional rate to <1%,
+- [x] Smoothed-seismicity PSHA conserves the total regional rate to <1%,
       near-fault sites exceed remote sites by >10×, and the collapsed-distance
       inflation (~2.1–2.5 g on-fault) is gone. NOTE (decision recorded during
       implementation): the committed GEM faults file carries no slip rates, so
@@ -109,9 +109,9 @@ numbers, paper sections 'Results', 'Probabilistic Hazard', 'Coulomb'.
       2023, ~1 g on-fault). The paper/README must state this as a known lower
       bound rather than quoting the old inflated range; README/paper PSHA
       numbers and fig10 regenerated from the new model.
-- [ ] A report stage regenerates `hazard_curves/*.csv` + manifest; the
+- [x] A report stage regenerates `hazard_curves/*.csv` + manifest; the
       dashboard's Browse link resolves.
-- [ ] `ruff check .` clean; full pytest suite green with new regression tests
+- [x] `ruff check .` clean; full pytest suite green with new regression tests
       for the kernel parity, rupture-distance selection, and rate
       conservation.
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -46,3 +46,4 @@ new spec from `TEMPLATE.md`, then drive steps 2–5 until every acceptance crite
 | [003](003-project-improvements.md) | Project improvements — CI test gate, de-duplication, structure | Done |
 | [004](004-v2-export-migration.md) | Migrate the artifact pipeline to API v2 (`/api/v2/export`) | Done |
 | [005](005-artifact-schema-v2.md) | Artifact schema v2 — drop zero-information columns | Draft |
+| [006](006-hazard-model-corrections.md) | Hazard-model corrections (rupture distance, PSHA source model, Coulomb kernel) | Done |


### PR DESCRIPTION
Closes out spec 006 (hazard-model corrections). All acceptance criteria were met and verified in PR #38 (Coulomb parity test, rupture-distance grade, PSHA rate conservation, regenerated artifacts, ruff + pytest green). Ticks the boxes, flips status to Done, and adds the row to the specs index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)