### PR TITLE
docs(spec): reject spec 005 — quake_exports columns are needed for research

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,10 @@ deploy. Specs 001–004 are Done; the active roadmap is `specs/005` (artifact sc
 - Data flows as pandas DataFrames with stable column names: `time_utc`, `mag`, `depth`,
   `lat`/`latitude`, `lon`/`longitude`, `location`. Validation/dedup happens in
   `export/writer.py`.
+- The published `quake_exports` artifact is a **research dataset** — keep all 32
+  columns; do NOT trim it (spec 005 was rejected for this reason). Its CSV headers
+  are per-file and not all in the same order (a known quirk): **parse by column name,
+  never by position.**
 
 ## Domain correctness (read before touching analysis/)
 

--- a/specs/005-artifact-schema-v2.md
+++ b/specs/005-artifact-schema-v2.md
@@ -1,10 +1,33 @@
 ---
 spec: 005
 title: A leaner published artifact schema ("artifact v2") for quake_exports CSV/JSON
-status: Draft            # Draft | Approved | In progress | Done
+status: Rejected        # Draft | Approved | In progress | Done | Rejected
 author: Claude (3-agent audit fan-out) + Aung Khant Zaw
 created: 2026-07-03
+resolved: 2026-07-07
 ---
+
+## Resolution (2026-07-07) — REJECTED, do not implement
+
+The owner decided the published `quake_exports` artifact is a **research
+dataset**, so its columns must be preserved: *"those data are needed for
+research purposes."* The audit's "unread by `src/mmeq`" read-set does not
+imply an external researcher can't use a column (e.g. the `timestamp` epoch,
+`shakemapURL`, or the sparse historical `nst`/`gap`/`dmin`/`rms` metrics). The
+premise of this spec — trimming the 32-column artifact — therefore does not
+hold, so D1 (column set) and D2 (breaking-change compatibility) are moot.
+
+The one loss-less idea (canonicalizing the per-file column order to fix the
+audit's "5 different header orders" minor, keeping all 32 columns) was also
+declined: consumers already parse by column name, so the header inconsistency
+is a cosmetic nuisance, and rewriting ~1,278 files to fix it carries more
+downside (one giant diff; a bytes-changed event for any positional consumer of
+a live research dataset) than the tidiness is worth. The "5 header orders"
+quirk stays a **documented known-quirk** — parse `quake_exports` CSVs by
+column name, never by position.
+
+The full design below is retained as a record of the analysis (and of why the
+paper is independent of the artifact schema — verified), not as work to do.
 
 ## Decision required (owner sign-off before any implementation)
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -45,5 +45,5 @@ new spec from `TEMPLATE.md`, then drive steps 2–5 until every acceptance crite
 | [002](002-go-export-rewrite.md) | Rewrite the fetch/export CLI in Go (separate branch) | Done |
 | [003](003-project-improvements.md) | Project improvements — CI test gate, de-duplication, structure | Done |
 | [004](004-v2-export-migration.md) | Migrate the artifact pipeline to API v2 (`/api/v2/export`) | Done |
-| [005](005-artifact-schema-v2.md) | Artifact schema v2 — drop zero-information columns | Draft |
+| [005](005-artifact-schema-v2.md) | Artifact schema v2 — drop zero-information columns | Rejected (columns needed for research) |
 | [006](006-hazard-model-corrections.md) | Hazard-model corrections (rupture distance, PSHA source model, Coulomb kernel) | Done |


### PR DESCRIPTION
The published `quake_exports` artifact is a **research dataset**, so its columns must be preserved (owner: *"those data are needed for research purposes"*). Spec 005's premise — trimming the 32-column artifact — doesn't hold, so it's marked **Rejected**.

- The audit's "unread by `src/mmeq`" read-set doesn't mean an external researcher can't use a column (the `timestamp` epoch, `shakemapURL`, the sparse historical `nst`/`gap`/`dmin`/`rms` metrics, etc).
- The one loss-less idea (canonicalize per-file column order to fix the "5 header orders" minor, keeping all columns) was also declined: consumers parse by name, so it's cosmetic, and rewriting ~1,278 files carries more downside than the tidiness is worth on a live dataset.
- The header-order quirk is now a **documented known-quirk** in CLAUDE.md: parse by column name, never by position.

Full spec design retained as an analysis record (incl. the verified finding that the paper is independent of the artifact schema). No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)